### PR TITLE
Proxy friendly `/events` path.

### DIFF
--- a/v2/esp-app.ts
+++ b/v2/esp-app.ts
@@ -8,7 +8,13 @@ import "./esp-logo";
 import cssReset from "./css/reset";
 import cssButton from "./css/button";
 
-window.source = new EventSource("/events");
+function getEventsUrl(){
+  url = window.location.pathname;
+  url += url.endsWith("/") ? "" : "/";
+  return url + "events";
+};
+
+window.source = new EventSource(getEventsUrl());
 
 interface Config {
   ota: boolean;


### PR DESCRIPTION
Take base path into account for EventSource, such that ESPHome devices can be reached through reverse proxy using path-prefix.

Use case:

When accessing the ESPHome device from another network through a (reverse-)proxy that uses path prefixes, `/events` cannot be reached. See esphome/issues#3462.

This PR solves that issue by taking the base path of the webpage and prepending that to the `/events` URL if applicable.