### PR TITLE
Proxy friendly API calls

### DIFF
--- a/v2/esp-app.ts
+++ b/v2/esp-app.ts
@@ -8,13 +8,12 @@ import "./esp-logo";
 import cssReset from "./css/reset";
 import cssButton from "./css/button";
 
-function getEventsUrl(){
-  url = window.location.pathname;
-  url += url.endsWith("/") ? "" : "/";
-  return url + "events";
-};
+function getBasePath() {
+  let str = window.location.pathname;
+  return str.endsWith("/") ? str.slice(0, -1) : str;
+}
 
-window.source = new EventSource(getEventsUrl());
+window.source = new EventSource(getBasePath() + "/events");
 
 interface Config {
   ota: boolean;
@@ -84,12 +83,18 @@ export default class EspApp extends LitElement {
   }
 
   ota() {
-    if (this.config.ota)
+    if (this.config.ota) {
+      let basePath = getBasePath();
       return html`<h2>OTA Update</h2>
-      <form method="POST" action="${window.location.pathname}/update" enctype="multipart/form-data">
+        <form
+          method="POST"
+          action="${basePath}/update"
+          enctype="multipart/form-data"
+        >
           <input class="btn" type="file" name="update" />
           <input class="btn" type="submit" value="Update" />
         </form>`;
+    }
   }
 
   render() {

--- a/v2/esp-app.ts
+++ b/v2/esp-app.ts
@@ -86,7 +86,7 @@ export default class EspApp extends LitElement {
   ota() {
     if (this.config.ota)
       return html`<h2>OTA Update</h2>
-        <form method="POST" action="/update" enctype="multipart/form-data">
+      <form method="POST" action="${window.location.pathname}/update" enctype="multipart/form-data">
           <input class="btn" type="file" name="update" />
           <input class="btn" type="submit" value="Update" />
         </form>`;

--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -24,6 +24,13 @@ interface entityConfig {
   speed: string;
 }
 
+function getBasePath() {
+  let str = window.location.pathname;
+  return str.endsWith("/") ? str.slice(0, -1) : str;
+}
+
+let basePath = getBasePath();
+
 @customElement("esp-entity-table")
 export class EntityTable extends LitElement {
   @state({ type: Array, reflect: true }) entities: entityConfig[] = [];
@@ -243,7 +250,7 @@ export class EntityTable extends LitElement {
   }
 
   restAction(entity: entityConfig, action: String) {
-    fetch(`${window.location.pathname}/${entity.domain}/${entity.id}/${action}`, {
+    fetch(`${basePath}/${entity.domain}/${entity.id}/${action}`, {
       method: "POST",
       body: "true",
     }).then((r) => {

--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -243,7 +243,7 @@ export class EntityTable extends LitElement {
   }
 
   restAction(entity: entityConfig, action: String) {
-    fetch(`/${entity.domain}/${entity.id}/${action}`, {
+    fetch(`${window.location.pathname}/${entity.domain}/${entity.id}/${action}`, {
       method: "POST",
       body: "true",
     }).then((r) => {


### PR DESCRIPTION
Take base path into account for API calls originating from webserver UI, such that ESPHome devices can be reached through reverse proxy using path-prefix.

This PR is an extension of #9, in which I did not take into account that for API calls the base path should also be prepended.

Should fix esphome/issues#3696