### PR TITLE
increase switch toggle timeout

### DIFF
--- a/v2/esp-switch.ts
+++ b/v2/esp-switch.ts
@@ -44,7 +44,7 @@ export class EspSwitch extends LitElement {
         this.toggleCallback = resolve;
         setTimeout(() => {
           reject();
-        }, 250);
+        }, 500);
       }).catch(() => {
         this.state = prevState;
         this.requestUpdate();


### PR DESCRIPTION
I've found with sub-optimal WiFi that the REST calls from the webserver UI can easily take longer than the 250ms rejection timeout (found values in range of 300 to 450ms on my network).

For most entity types this is no big deal, but in case of the switch this causes toggles in quick succession.

Seeing as on decent networks this timeout should not be reached unless there's an actual communication issue I'm wondering if the value could be increased beyond 500ms though, as that would provide a better margin. Thoughts?