### PR TITLE
Add brightness slider for Lights.

### DIFF
--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -331,7 +331,7 @@ export class EntityTable extends LitElement {
           background-color: var(--primary-color, currentColor);
         }
         input[type="range"] {
-          width: calc(100% - 4rem);
+          width: calc(100% - 8rem);
           height: 0.75rem;
         }
         .range {

--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -165,14 +165,15 @@ export class EntityTable extends LitElement {
               1
             )
           : "",
-        entity.effects &&
-          this.select(
-            entity,
-            "turn_on",
-            "effect",
-            entity.effects,
-            entity.effect
-          ),
+        entity.effects.filter((v) => v != "None").length
+          ? this.select(
+              entity,
+              "turn_on",
+              "effect",
+              entity.effects,
+              entity.effect
+            )
+          : "",
       ];
     }
 

--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -14,6 +14,7 @@ interface entityConfig {
   when: string;
   icon?: string;
   option?: string[];
+  brightness?: Number;
   target_temperature?: Number;
   target_temperature_low?: Number;
   target_temperature_high?: Number;
@@ -150,9 +151,20 @@ export class EntityTable extends LitElement {
       ];
     }
 
-    if (entity.domain === "light")
+    if (entity.domain === "light") {
       return [
         this.switch(entity),
+        entity.brightness
+          ? this.range(
+              entity,
+              "turn_on",
+              "brightness",
+              entity.brightness,
+              0,
+              255,
+              1
+            )
+          : "",
         entity.effects &&
           this.select(
             entity,
@@ -162,6 +174,8 @@ export class EntityTable extends LitElement {
             entity.effect
           ),
       ];
+    }
+
     if (entity.domain === "lock")
       return html`${this.actionButton(entity, "🔐", "lock")}
       ${this.actionButton(entity, "🔓", "unlock")}
@@ -316,7 +330,7 @@ export class EntityTable extends LitElement {
           background-color: var(--primary-color, currentColor);
         }
         input[type="range"] {
-          width: calc(100% - 8rem);
+          width: calc(100% - 4rem);
           height: 0.75rem;
         }
         .range {


### PR DESCRIPTION
Adds a brightness slider for lights that support it.

I've purposely not touched upon RGB, or color temperature as that seems to require additional data and probably other UI elements than what can be acomplished using sliders.

Should fix issue #15.

Example of added sliders:
![image](https://user-images.githubusercontent.com/68224306/198703972-d3e80c58-5df7-467b-95b0-d7432d7ee10f.png)
