### PR TITLE
Display the esphome:comment

### DIFF
--- a/v2/esp-app.ts
+++ b/v2/esp-app.ts
@@ -8,12 +8,14 @@ import "./esp-switch";
 import "./esp-logo";
 import cssReset from "./css/reset";
 import cssButton from "./css/button";
+import { throws } from "assert";
 
 window.source = new EventSource(getBasePath() + "/events");
 
 interface Config {
   ota: boolean;
   title: string;
+  comment: string;
 }
 
 @customElement("esp-app")
@@ -24,11 +26,15 @@ export default class EspApp extends LitElement {
   beat!: HTMLSpanElement;
 
   version: String = import.meta.env.PACKAGE_VERSION;
-  config: Config = { ota: false, title: "" };
+  config: Config = { ota: false, title: "", comment: "" };
 
   darkQuery: MediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
 
-  frames = [{ color: "inherit" }, { color: "red", transform: "scale(1.25) translateY(-30%)" }, { color: "inherit" }];
+  frames = [
+    { color: "inherit" },
+    { color: "red", transform: "scale(1.25) translateY(-30%)" },
+    { color: "inherit" },
+  ];
 
   constructor() {
     super();
@@ -94,6 +100,12 @@ export default class EspApp extends LitElement {
   }
 
   render() {
+    let comment_header;
+    if (this.config.comment != undefined) {
+      comment_header = html` <h3>${this.config.comment}</h3> `;
+    } else {
+      comment_header = html``;
+    }
     return html`
       <h1>
         <a href="https://esphome.io/web-api" class="logo">
@@ -102,6 +114,7 @@ export default class EspApp extends LitElement {
         ${this.config.title}
         <span id="beat" title="${this.version}">❤</span>
       </h1>
+      ${comment_header}
       <main class="flex-grid-half">
         <section class="col">
           <esp-entity-table></esp-entity-table>
@@ -174,6 +187,10 @@ export default class EspApp extends LitElement {
         h2 {
           border-bottom: 1px solid #eaecef;
           margin-bottom: 0.25rem;
+        }
+        h3 {
+          text-align: center;
+          margin: 0.5rem 0;
         }
         #beat {
           float: right;

--- a/v2/esp-app.ts
+++ b/v2/esp-app.ts
@@ -8,7 +8,6 @@ import "./esp-switch";
 import "./esp-logo";
 import cssReset from "./css/reset";
 import cssButton from "./css/button";
-import { throws } from "assert";
 
 window.source = new EventSource(getBasePath() + "/events");
 

--- a/v2/esp-app.ts
+++ b/v2/esp-app.ts
@@ -1,4 +1,4 @@
-import { LitElement, html, css, PropertyValues } from "lit";
+import { LitElement, html, css, PropertyValues, nothing } from "lit";
 import { customElement, state, query } from "lit/decorators.js";
 import { getBasePath } from "./esp-entity-table";
 
@@ -99,13 +99,13 @@ export default class EspApp extends LitElement {
     }
   }
 
+  renderComment() {
+    return this.config.comment
+      ? html`<h3>${this.config.comment}</h3>`
+      : nothing;
+  }
+
   render() {
-    let comment_header;
-    if (this.config.comment != undefined) {
-      comment_header = html` <h3>${this.config.comment}</h3> `;
-    } else {
-      comment_header = html``;
-    }
     return html`
       <h1>
         <a href="https://esphome.io/web-api" class="logo">
@@ -114,7 +114,7 @@ export default class EspApp extends LitElement {
         ${this.config.title}
         <span id="beat" title="${this.version}">❤</span>
       </h1>
-      ${comment_header}
+      ${this.renderComment()}
       <main class="flex-grid-half">
         <section class="col">
           <esp-entity-table></esp-entity-table>


### PR DESCRIPTION
This change takes the `comment` field passed in the `ping` message, and displays it under the main title `<h1>` in it's own `<h3>` tag. This  comment comes from the `esphome:comment` configuration.

If there is no `esphome:comment` configured, it will not add the `<h3>` tag

Note:
- For this to work, pull request this PR in [esphome](https://github.com/esphome/esphome-frontend) needs to be merged to add the `comment` to the `ping` message: https://github.com/esphome/esphome/pull/4246
- This is backwards compatible, so that if an older version `esphome` instance uses this frontend, it work work as normal.

Example config:
```yaml
esphome:
  name: tester-d8407a
  comment: This Will appear in the WebConsole's header

esp8266:
  board: esp01_1m

# Enable logging
logger:

ota:

api:

web_server:

wifi:
  ssid: !secret wifi_ssid
  password: !secret wifi_password

  # Enable fallback hotspot (captive portal) in case wifi connection fails
  ap:
    ssid: "Tester-D8407A Fallback Hotspot"
    password: "lE7PR8uNHwlX"

captive_portal:
```
Example Web Server:
<img width="694" alt="image" src="https://user-images.githubusercontent.com/122615/210124007-2ba61a0a-70a2-471c-a68f-c9f66f54f353.png">
Or with no `esphome/comment` configured gives:
<img width="783" alt="image" src="https://user-images.githubusercontent.com/122615/210124690-ba59c094-d461-4475-9929-06bf23271a40.png">

