### PR TITLE
Handle assumed_state switches

### DIFF
--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -14,6 +14,7 @@ interface entityConfig {
   when: string;
   icon?: string;
   option?: string[];
+  assumed_state?: boolean;
   brightness?: Number;
   target_temperature?: Number;
   target_temperature_low?: Number;
@@ -136,7 +137,12 @@ export class EntityTable extends LitElement {
   }
 
   control(entity: entityConfig) {
-    if (entity.domain === "switch") return [this.switch(entity)];
+    if (entity.domain === "switch") {
+      if (entity.assumed_state)
+        return html`${this.actionButton(entity, "❌", "turn_off")}
+        ${this.actionButton(entity, "✔️", "turn_on")}`;
+      else return [this.switch(entity)];
+    }
 
     if (entity.domain === "fan") {
       return [
@@ -344,7 +350,6 @@ export class EntityTable extends LitElement {
         .range {
           text-align: center;
         }
-
       `,
     ];
   }


### PR DESCRIPTION
Fixes esphome/issues#4001

Correctly handle assumed_state switches in Web UI.
Requires esphome/esphome#4259.

Note:
Could not find propper symbols for 'on' / 'off' so had to settle for the cross & checkmark emoji, as text in the buttons also does not seem to look right. Open to other suggestions of course! ;)

![image](https://user-images.githubusercontent.com/68224306/210551097-07e6b621-1318-4a45-8084-085ad0ad9717.png)
