### PR TITLE
Hide the Actions column unless an entity has actions available.

### DIFF
--- a/v2/esp-entity-table.ts
+++ b/v2/esp-entity-table.ts
@@ -35,6 +35,7 @@ let basePath = getBasePath();
 @customElement("esp-entity-table")
 export class EntityTable extends LitElement {
   @state({ type: Array, reflect: true }) entities: entityConfig[] = [];
+  @state({ type: Boolean, reflect: true }) has_controls: boolean = false;
 
   constructor() {
     super();
@@ -57,6 +58,7 @@ export class EntityTable extends LitElement {
         } as entityConfig;
         this.entities.push(entity);
         this.entities.sort((a, b) => (a.name < b.name ? -1 : 1));
+        this.has_controls ||= this.control(entity).length||0>0
         this.requestUpdate();
       } else {
         delete data.id;
@@ -280,7 +282,7 @@ export class EntityTable extends LitElement {
           <tr>
             <th>Name</th>
             <th>State</th>
-            <th>Actions</th>
+            ${this.has_controls ? html`<th>Actions</th>` : html``}
           </tr>
         </thead>
         <tbody>
@@ -289,7 +291,7 @@ export class EntityTable extends LitElement {
               <tr>
                 <td>${component.name}</td>
                 <td>${component.state}</td>
-                <td>${this.control(component)}</td>
+                ${this.has_controls ? html`<td>${this.control(component)}</td>` : html``}
               </tr>
             `
           )}


### PR DESCRIPTION
This is a minor enhancement to hide the Actions column by default unless an entity has actions to control.

This is designed for sensor nodes which have no controllable actions or output, but instead have information to display.

This works well with #28

|Before|After|
|---|---|
| <img width="595" alt="Screen Shot 2023-02-12 at 8 55 06 pm" src="https://user-images.githubusercontent.com/767313/218306942-011de9bd-c589-4443-9db1-efa772c58292.png"> | <img width="597" alt="Screen Shot 2023-02-12 at 9 08 51 pm" src="https://user-images.githubusercontent.com/767313/218307452-0397c5f9-b429-4b07-b0eb-b53c682847c4.png"> |

Loading example of with/without entites with actions (Entity with actions intentionally placed last)

|With Actions|Without Actions|
|---|---|
| <video src="https://user-images.githubusercontent.com/767313/218307294-5b39c177-5445-41e6-8e3c-86e086d89cc2.mov"> | <video src="https://user-images.githubusercontent.com/767313/218307338-d0d643ba-2b00-4798-8412-e6dd291d1820.mov"> |


In the event an element does indeed have an action, the column is instantly shown.

