### PR TITLE
Remove outdated warning

### DIFF
--- a/captive-portal/index.html
+++ b/captive-portal/index.html
@@ -13,7 +13,6 @@
       <aside>
         The ESP will now try to connect to the network...<br>
         Please give it some time to connect.<br>
-        Note: Copy the changed network to your YAML file - the next OTA update will overwrite these settings.
       </aside>
       <span id="net">
       </span>


### PR DESCRIPTION
This warning is not true since 2022.11.0.

_Some components such as Captive Portal, Improv via Serial and Improv via BLE enable the user to send and save Wi-Fi credentials to the device. Beginning in 2022.11.0, as long as no credentials are set in the config file, and firmware is uploaded without erasing the flash (via OTA), the device will keep the saved credentials._

https://esphome.io/components/wifi.html#user-entered-credentials