### PR TITLE
V3: restore brotli (.br) compilation

### DIFF
--- a/packages/v3/vite.config.ts
+++ b/packages/v3/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
         additionalFiles: [],
         customCompression: (content) =>
           brotliCompressSync(Buffer.from(content)),
-        fileName: ".gz",
+        fileName: ".br",
       }),
       enforce: "post",
       apply: "build",


### PR DESCRIPTION
Restores the compilation of www.js.br files that was inadvertently removed via #54