### PR TITLE
Force ota update to application/octet-stream

### DIFF
--- a/packages/v3/src/esp-app.ts
+++ b/packages/v3/src/esp-app.ts
@@ -150,7 +150,7 @@ export default class EspApp extends LitElement {
           enctype="multipart/form-data"
           class="tab-container"
         >
-          <input class="btn" type="file" name="update" />
+          <input class="btn" type="file" name="update" accept="application/octet-stream" />
           <input class="btn" type="submit" value="Update" />
         </form>`;
     }


### PR DESCRIPTION
It seems like there can be some confusion (#52) around which file should be picked for OTA updates. This is a sort of RFC helping steer people to the right types of files.

Not sure if this could be inadvertently too restrictive if another tool names or formats them differently. Perhaps it's best to add a note about "Usually has a `.bin` extension" or something.

I tested this on macOS, but need help testing other platforms.

![firmware.bin](https://github.com/esphome/esphome-webserver/assets/706138/0ca4994d-99a3-4db6-bf2f-14c5917cb941)