### PR TITLE
Change online indicator to green dot

### DIFF
--- a/packages/v3/src/css/app.ts
+++ b/packages/v3/src/css/app.ts
@@ -60,6 +60,9 @@ export default css`
     float: left;
     color: rgba(127, 127, 127, 0.5);
   }
+  .connected {
+    color: rgba(0, 157, 16, 0.75);
+  }
   esp-logo {
     float: left;
     line-height: 1em;

--- a/packages/v3/src/esp-app.ts
+++ b/packages/v3/src/esp-app.ts
@@ -69,7 +69,7 @@ export default class EspApp extends LitElement {
 
   darkQuery: MediaQueryList = window.matchMedia("(prefers-color-scheme: dark)");
 
-  frames = [{}, { color: "red", transform: "scale(1.25)" }, {}];
+  frames = [{}, { color: "rgba(0, 196, 21, 0.75)" }, {}];
 
   constructor() {
     super();
@@ -187,9 +187,9 @@ export default class EspApp extends LitElement {
           <esp-logo></esp-logo>
         </a>
         <iconify-icon
-          .icon="${!!this.connected ? "mdi:heart" : "mdi:heart-off"}"
+          .icon="${!!this.connected ? "mdi:circle" : "mdi:circle-off-outline"}"
           .title="${this.uptime()}"
-          class="top-icon"
+          class="top-icon ${!!this.connected ? "connected" : ""}"
           id="beat"
         ></iconify-icon>
         <a


### PR DESCRIPTION
As mentioned in "V3 fixes and feature requests" #56

> Adjust beating heart to a green dot or only display an offline indicator

This changes the ping/heartbeat/online indicator to be a green dot. I personally still like having some sort of periodic "ping" indicator, so I kept the animation, but it only switches to a more vibrant green and does not scale up like the heart did.

| | Online | Ping | Offline |
|-|-|-|-|
| Dark | ![dark online](https://github.com/esphome/esphome-webserver/assets/706138/ba472632-b256-4f39-8c5c-0a1ee2793a9a) | ![dark ping](https://github.com/esphome/esphome-webserver/assets/706138/6bafdb4c-47b8-48f2-86b2-7656ebbf0330) | ![image](https://github.com/esphome/esphome-webserver/assets/706138/57dbb3b3-18f8-40b2-92d2-de10c65bcd40) |
| Light | ![light online](https://github.com/esphome/esphome-webserver/assets/706138/e8ac4386-1c86-4a28-9a66-424b00f2b4fb) | ![light ping](https://github.com/esphome/esphome-webserver/assets/706138/d15250fc-9c85-4ca9-8047-acff83c947c9) |  ![light offline](https://github.com/esphome/esphome-webserver/assets/706138/c6069a98-086b-4669-87f4-d19eaa283ba1) |

https://github.com/esphome/esphome-webserver/assets/706138/28235398-924d-46cb-9c68-816f5ba1d226

https://github.com/esphome/esphome-webserver/assets/706138/903f5090-de05-4710-81db-5d1bc9a88186