### PR TITLE
Add version check to make_header.sh

### DIFF
--- a/packages/v2/package.json
+++ b/packages/v2/package.json
@@ -7,7 +7,7 @@
     "xbuild": "vite build --emptyOutDir",
     "build": "vite build --emptyOutDir && npm run deploy",
     "serve": "vite preview",
-    "deploy": "bash -c '../../scripts/make_header.sh ../../_static/v2 server_index.h web_server'"
+    "deploy": "bash -c '../../scripts/make_header.sh ../../_static/v2 server_index_v2.h web_server 2'"
   },
   "dependencies": {
     "http-proxy-middleware": "^2.0.1",

--- a/packages/v3/package.json
+++ b/packages/v3/package.json
@@ -7,7 +7,7 @@
     "xbuild": "vite build --emptyOutDir",
     "build": "vite build --emptyOutDir && npm run deploy",
     "serve": "vite preview",
-    "deploy": "bash -c '../../scripts/make_header.sh ../../_static/v3 server_index.h web_server'"
+    "deploy": "bash -c '../../scripts/make_header.sh ../../_static/v3 server_index_v3.h web_server 3'"
   },
   "dependencies": {
     "chart.js": "^4.4.1",

--- a/scripts/make_header.sh
+++ b/scripts/make_header.sh
@@ -2,6 +2,7 @@
 cat <<EOT > ./$1/$2
 #pragma once
 // Generated from https://github.com/esphome/esphome-webserver
+$(if [ -n "$4" ]; then echo "#if USE_WEBSERVER_VERSION == $4"; fi)
 #include "esphome/core/hal.h"
 namespace esphome {
 
@@ -14,5 +15,6 @@ cat <<EOT >> ./$1/$2
 
 }  // namespace $3
 }  // namespace esphome
+$(if [ -n "$4" ]; then echo "#endif"; fi)
 EOT
 ls -l ./$1/$2


### PR DESCRIPTION
This adds a 4th parameter to `make_header.sh` that adds a `USE_WEBSERVER_VERSION` for the given value.

This wraps the `const uint8_t INDEX_GZ[] PROGMEM` in an `#if USE_WEBSERVER_VERSION == $4` so that both versions can be included and the right version will be used based on the `version` specified in the config yaml.

Confirmed this condition gets added to `v2` and `v3` packages, but not `captive_portal`.

This also renames the indexes for `v2` and `v3` to `server_index_v2.h` and `server_index_v3.h` respectively so that it's clearer which versions are being referred to. I can leave this part off but then renaming will be needed when copying it into the `web_server` component in `esphome`.