### PR TITLE
v3 Silder mobile devices fix

### DIFF
--- a/packages/v3/src/esp-range-slider.ts
+++ b/packages/v3/src/esp-range-slider.ts
@@ -192,6 +192,7 @@ export class EspRangeSlider extends LitElement {
           -webkit-appearance: none;
           margin: 20px 0;
           width: 100%;
+          touch-action: none;
         }
         input[type=range]:focus {
           outline: none;


### PR DESCRIPTION
Prevent the display from scolling if you are tring to change the value with a slider. 
The problem is issue #80. Because of that the display on a mobile device will be scrollable side to side which i think should never be the case.

But anyway if it happends, this fix will let the user use the slider and prevent the display from sliding if you touch the slider