### PR TITLE
v3 light slider width

### DIFF
--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -486,7 +486,8 @@ class ActionRenderer {
   render_light() {
     if (!this.entity) return;
     return [
-      html`<div class="entity">
+      html`<div class="entity" style="
+      width: 100%;">
         ${this._switch(this.entity)}
         ${this.entity.brightness
           ? this._range(


### PR DESCRIPTION
Allow the slider on the light control to use `width: 100%`
![webserver-v3-light-slider-width](https://github.com/esphome/esphome-webserver/assets/4093064/a51a9402-e338-418d-b23b-639a697e49fb)
