### PR TITLE
Add #ifdef USE_WEBSERVER_LOCAL to make_header.sh

### DIFF
--- a/scripts/make_header.sh
+++ b/scripts/make_header.sh
@@ -2,7 +2,10 @@
 cat <<EOT >./$1/$2
 #pragma once
 // Generated from https://github.com/esphome/esphome-webserver
-$(if [ -n "$4" ]; then echo "#if USE_WEBSERVER_VERSION == $4"; fi)
+$(if [ -n "$4" ]; then
+  echo "#ifdef USE_WEBSERVER_LOCAL"
+  echo "#if USE_WEBSERVER_VERSION == $4"
+fi)
 #include "esphome/core/hal.h"
 namespace esphome {
 
@@ -15,5 +18,8 @@ cat <<EOT >>./$1/$2
 
 }  // namespace $3
 }  // namespace esphome
-$(if [ -n "$4" ]; then echo "#endif"; fi)
+$(if [ -n "$4" ]; then
+  echo "#endif"
+  echo "#endif"
+fi)
 EOT


### PR DESCRIPTION
As mentioned in https://github.com/esphome/esphome/pull/6563#issuecomment-2071068707

> It could pay to also add #ifdef USE_WEBSERVER_LOCAL into the generated headers which would solve this problem entirely.

This adds that `#ifdef`.

Do we want something similar for `captive_index.h`? If so, I might restructure this script a bit so it takes in the `#ifdef` name directly instead of just adding `USE_WEBSERVER_LOCAL` when a version number is passed.