### PR TITLE
[v3] fix sorting to sort by name if sorting weights ar equal

### DIFF
--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -105,9 +105,13 @@ export class EntityTable extends LitElement implements RestAction {
           return a.entity_category < b.entity_category  
             ? -1  
             : a.entity_category == b.entity_category  
-            ? sortA < sortB  
-              ? -1  
-              : 1  
+            ? sortA === sortB  
+              ? a.name < b.name
+                ? -1
+                : 1  
+              : sortA < sortB
+                ? -1
+                : 1   
             : 1  
         });         
         this.requestUpdate();

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -106,7 +106,7 @@ export class EntityTable extends LitElement implements RestAction {
             ? -1  
             : a.entity_category == b.entity_category  
             ? sortA === sortB  
-              ? a.name < b.name
+              ? a.name.toLowerCase() < b.name.toLowerCase()
                 ? -1
                 : 1  
               : sortA < sortB


### PR DESCRIPTION
Since the esp adds a default sorting weight of 50 to all entitys they would not get sorted by the name but instead get sorted by the order the esp send them to the client.

Discord discussion:
https://discordapp.com/channels/429907082951524364/1245646776094949471/1263939557276258415