### PR TITLE
[v3] Show state for cover and lock

### DIFF
--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -607,16 +607,16 @@ class ActionRenderer {
 
   render_lock() {
     if (!this.entity) return;
-    return html`${this._actionButton(this.entity, "🔐", "lock")}
-    ${this._actionButton(this.entity, "🔓", "unlock")}
+    return html`${this._actionButton(this.entity, "🔐", "lock", this.entity.state === "LOCKED")}
+    ${this._actionButton(this.entity, "🔓", "unlock", this.entity.state === "UNLOCKED")}
     ${this._actionButton(this.entity, "↑", "open")} `;
   }
 
   render_cover() {
     if (!this.entity) return;
-    return html`${this._actionButton(this.entity, "↑", "open")}
-    ${this._actionButton(this.entity, "☐", "stop")}
-    ${this._actionButton(this.entity, "↓", "close")}`;
+    return html`${this._actionButton(this.entity, "↑", "open", this.entity.state === "OPEN")}
+    ${this._actionButton(this.entity, "☐", "stop", )}
+    ${this._actionButton(this.entity, "↓", "close", this.entity.state === "CLOSED")}`;
   }
 
   render_button() {

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -665,7 +665,7 @@ class ActionRenderer {
   render_cover() {
     if (!this.entity) return;
     return html`${this._actionButton(this.entity, "↑", "open", this.entity.state === "OPEN")}
-    ${this._actionButton(this.entity, "☐", "stop", )}
+    ${this._actionButton(this.entity, "☐", "stop")}
     ${this._actionButton(this.entity, "↓", "close", this.entity.state === "CLOSED")}`;
   }
 


### PR DESCRIPTION
Adds a visual representaion of the state of the cover and lock component
depends on #129 and #133

fixes #60, fixes #61

befor
![Bildschirmfoto vom 2025-02-14 17-12-37](https://github.com/user-attachments/assets/9ce26150-d6cb-475b-9477-26c0e54e5689)


after
![Bildschirmfoto vom 2025-02-14 17-13-33](https://github.com/user-attachments/assets/8d151681-95c9-42f3-9188-30554c26030b)
