### PR TITLE
fix(v2): capitalize 'Level' in log header

### DIFF
--- a/packages/v2/src/esp-log.ts
+++ b/packages/v2/src/esp-log.ts
@@ -77,7 +77,7 @@ export class DebugLog extends LitElement {
           <thead>
             <tr>
               <th>Time</th>
-              <th>level</th>
+              <th>Level</th>
               <th>Tag</th>
               <th>Message</th>
             </tr>


### PR DESCRIPTION
Fixes #144

This PR corrects a simple typo in the v2 webserver where 'level' was lowercase in the log table header.

**Changes:**
- Changed `<th>level</th>` to `<th>Level</th>` in `packages/v2/src/esp-log.ts`

**Details:**
- Makes v2 consistent with v3 which already has the correct capitalization
- Follows proper header capitalization conventions
- Addresses the exact issue reported in #144

The log header now properly displays "Time Level Tag Message" instead of "Time level Tag Message".