### PR TITLE
Support new hierarchical URL format with backward compatibility

### DIFF
--- a/packages/v1/src/webserver-v1.js
+++ b/packages/v1/src/webserver-v1.js
@@ -70,6 +70,27 @@ source.addEventListener('state', function (e) {
     document.getElementById(data.id).children[1].innerText = data.state;
 });
 
+// Build URL path for entity
+// New firmware: uses data attributes -> /{domain}/{device?}/{name}/{action}
+// Old firmware: parses from id attribute -> /{domain}/{object_id}/{action}
+function buildEntityUrl(row, action) {
+    // Check for new firmware (has data-domain attribute)
+    if (row.dataset.domain) {
+        const domain = row.dataset.domain;
+        const name = encodeURIComponent(row.dataset.name);
+        const device = row.dataset.device;
+        if (device) {
+            return '/' + domain + '/' + encodeURIComponent(device) + '/' + name + '/' + action;
+        }
+        return '/' + domain + '/' + name + '/' + action;
+    }
+    // Fall back to old format: id is "domain-object_id"
+    const parts = row.id.split('-');
+    const domain = parts[0];
+    const objectId = parts.slice(1).join('-');
+    return '/' + domain + '/' + objectId + '/' + action;
+}
+
 const states = document.getElementById("states");
 let i = 0, row;
 for (; row = states.rows[i]; i++) {
@@ -79,24 +100,22 @@ for (; row = states.rows[i]; i++) {
 
     for (const domain of actions){
         if (row.classList.contains(domain[0])) {
-            let id = row.id.substr(domain[0].length+1);
             for (let j=0;j<row.children[2].children.length && j < domain[1].length; j++){
                 row.children[2].children[j].addEventListener('click', function () {
                     const xhr = new XMLHttpRequest();
-                    xhr.open("POST", '/'+domain[0]+'/' + id + '/' + domain[1][j], true);
+                    xhr.open("POST", buildEntityUrl(row, domain[1][j]), true);
                     xhr.send();
                 });
             }
         }
-    }   
+    }
     for (const domain of multi_actions){
         if (row.classList.contains(domain[0])) {
-            let id = row.id.substr(domain[0].length+1);       
             row.children[2].children[0].addEventListener('change', function () {
                 const xhr = new XMLHttpRequest();
-                xhr.open("POST", '/'+domain[0]+'/' + id + '/set?'+domain[1]+'=' + encodeURIComponent(this.value), true);
+                xhr.open("POST", buildEntityUrl(row, 'set') + '?' + domain[1] + '=' + encodeURIComponent(this.value), true);
                 xhr.send();
             });
         }
-    }   
+    }
 }

--- a/packages/v1/src/webserver-v1.js
+++ b/packages/v1/src/webserver-v1.js
@@ -67,7 +67,28 @@ multi_actions = [
 
 source.addEventListener('state', function (e) {
     const data = JSON.parse(e.data);
-    document.getElementById(data.id).children[1].innerText = data.state;
+    // New firmware sends id as "domain/name" or "domain/device/name"
+    // Old firmware sends id as "domain-object_id"
+    // Try getElementById first (works for old format), then query by data attributes
+    let row = document.getElementById(data.id);
+    if (!row && data.id.includes('/')) {
+        // New format: parse and find by data attributes
+        const parts = data.id.split('/');
+        const domain = parts[0];
+        if (parts.length === 3) {
+            // domain/device/name
+            const device = CSS.escape(parts[1]);
+            const name = CSS.escape(parts[2]);
+            row = document.querySelector(`tr[data-domain="${domain}"][data-device="${device}"][data-name="${name}"]`);
+        } else {
+            // domain/name
+            const name = CSS.escape(parts[1]);
+            row = document.querySelector(`tr[data-domain="${domain}"][data-name="${name}"]:not([data-device])`);
+        }
+    }
+    if (row && data.state !== undefined) {
+        row.children[1].innerText = data.state;
+    }
 });
 
 // Build URL path for entity

--- a/packages/v1/src/webserver-v1.js
+++ b/packages/v1/src/webserver-v1.js
@@ -113,8 +113,8 @@ function buildEntityUrl(row, action) {
 }
 
 const states = document.getElementById("states");
-let i = 0, row;
-for (; row = states.rows[i]; i++) {
+for (let i = 0; i < states.rows.length; i++) {
+    const row = states.rows[i];  // Block-scoped copy for closure
     if (!row.children[2].children.length) {
         continue;
     }
@@ -122,9 +122,10 @@ for (; row = states.rows[i]; i++) {
     for (const domain of actions){
         if (row.classList.contains(domain[0])) {
             for (let j=0;j<row.children[2].children.length && j < domain[1].length; j++){
+                const action = domain[1][j];  // Block-scoped copy for closure
                 row.children[2].children[j].addEventListener('click', function () {
                     const xhr = new XMLHttpRequest();
-                    xhr.open("POST", buildEntityUrl(row, domain[1][j]), true);
+                    xhr.open("POST", buildEntityUrl(row, action), true);
                     xhr.send();
                 });
             }
@@ -132,9 +133,10 @@ for (; row = states.rows[i]; i++) {
     }
     for (const domain of multi_actions){
         if (row.classList.contains(domain[0])) {
+            const field = domain[1];  // Block-scoped copy for closure
             row.children[2].children[0].addEventListener('change', function () {
                 const xhr = new XMLHttpRequest();
-                xhr.open("POST", buildEntityUrl(row, 'set') + '?' + domain[1] + '=' + encodeURIComponent(this.value), true);
+                xhr.open("POST", buildEntityUrl(row, 'set') + '?' + field + '=' + encodeURIComponent(this.value), true);
                 xhr.send();
             });
         }

--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -156,7 +156,7 @@ export class EntityTable extends LitElement implements RestAction {
           ${this.entities.map(
             (component) => html`
               <tr>
-                <td>${component.name}</td>
+                <td>${component.device ? `[${component.device}] ` : ''}${component.name}</td>
                 <td>${component.state}</td>
                 ${this.has_controls
                   ? html`<td>

--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -11,6 +11,7 @@ interface entityConfig {
   detail: string;
   value: string;
   name: string;
+  device?: string;  // Device name for hierarchical URLs (sub-devices only)
   when: string;
   icon?: string;
   option?: string[];
@@ -45,6 +46,36 @@ export function getBasePath() {
 
 let basePath = getBasePath();
 
+// ID format detection and parsing helpers
+// New format: "domain/entity_name" or "domain/device_name/entity_name"
+// Old format: "domain-object_id" (deprecated)
+
+function isNewIdFormat(id: string): boolean {
+  return id.includes('/');
+}
+
+function parseDomainFromId(id: string): string {
+  if (isNewIdFormat(id)) {
+    return id.split('/')[0];
+  }
+  // Old format: domain-object_id
+  return id.split('-')[0];
+}
+
+function buildEntityActionUrl(entity: entityConfig, action: string): string {
+  if (isNewIdFormat(entity.unique_id)) {
+    // New format: /{domain}/{device?}/{name}/{action}
+    const entityName = encodeURIComponent(entity.name);
+    const devicePart = entity.device
+      ? `${encodeURIComponent(entity.device)}/`
+      : '';
+    return `${basePath}/${entity.domain}/${devicePart}${entityName}/${action}`;
+  }
+  // Old format: /{domain}/{object_id}/{action}
+  const objectId = entity.unique_id.split('-').slice(1).join('-');
+  return `${basePath}/${entity.domain}/${objectId}/${action}`;
+}
+
 interface RestAction {
   restAction(entity?: entityConfig, action?: string): void;
 }
@@ -63,13 +94,13 @@ export class EntityTable extends LitElement implements RestAction {
       const data = JSON.parse(messageEvent.data);
       let idx = this.entities.findIndex((x) => x.unique_id === data.id);
       if (idx === -1 && data.id) {
-        // Dynamically add discovered..
-        let parts = data.id.split("-");
+        // Dynamically add discovered entity
+        // domain comes from JSON (new format) or parsed from id (old format)
+        const domain = data.domain || parseDomainFromId(data.id);
         let entity = {
           ...data,
-          domain: parts[0],
+          domain: domain,
           unique_id: data.id,
-          id: parts.slice(1).join("-"),
         } as entityConfig;
         entity.has_action = this.hasAction(entity);
         if (entity.has_action) {
@@ -101,7 +132,7 @@ export class EntityTable extends LitElement implements RestAction {
   }
 
   restAction(entity: entityConfig, action: string) {
-    fetch(`${basePath}/${entity.domain}/${entity.id}/${action}`, {
+    fetch(buildEntityActionUrl(entity, action), {
       method: "POST",
       headers:{
         'Content-Type': 'application/x-www-form-urlencoded'

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -97,7 +97,17 @@ function buildEntityActionUrl(basePath: string, entity: entityConfig, action: st
 
 function buildIdFetchUrl(basePath: string, id: string): string {
   // URL-encode each path segment for fetching detail_all
-  const urlPath = id.split('/').map((s: string) => encodeURIComponent(s)).join('/');
+  let urlPath: string;
+  if (isNewIdFormat(id)) {
+    // New format: domain/name or domain/device/name
+    urlPath = id.split('/').map((s: string) => encodeURIComponent(s)).join('/');
+  } else {
+    // Old format: domain-object_id -> domain/object_id
+    const parts = id.split('-');
+    const domain = parts[0];
+    const objectId = parts.slice(1).join('-');
+    urlPath = `${domain}/${encodeURIComponent(objectId)}`;
+  }
   return `${basePath}/${urlPath}?detail=all`;
 }
 

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -352,7 +352,7 @@ export class EntityTable extends LitElement implements RestAction {
                           ></iconify-icon>`
                         : nothing}
                     </div>
-                    <div>${component.name}</div>
+                    <div>${component.device ? `[${component.device}] ` : ''}${component.name}</div>
                     <div>
                       ${this.has_controls && component.has_action
                         ? this.control(component)

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -18,6 +18,7 @@ interface entityConfig {
   detail: string;
   value: string;
   name: string;
+  device?: string;  // Device name for hierarchical URLs (sub-devices only)
   entity_category?: number;
   when: string;
   icon?: string;
@@ -64,6 +65,42 @@ export function getBasePath() {
   return str.endsWith("/") ? str.slice(0, -1) : str;
 }
 
+// ID format detection and parsing helpers
+// New format: "domain/entity_name" or "domain/device_name/entity_name"
+// Old format: "domain-object_id" (deprecated)
+
+function isNewIdFormat(id: string): boolean {
+  return id.includes('/');
+}
+
+function parseDomainFromId(id: string): string {
+  if (isNewIdFormat(id)) {
+    return id.split('/')[0];
+  }
+  // Old format: domain-object_id
+  return id.split('-')[0];
+}
+
+function buildEntityActionUrl(basePath: string, entity: entityConfig, action: string): string {
+  if (isNewIdFormat(entity.unique_id)) {
+    // New format: /{domain}/{device?}/{name}/{action}
+    const entityName = encodeURIComponent(entity.name);
+    const devicePart = entity.device
+      ? `${encodeURIComponent(entity.device)}/`
+      : '';
+    return `${basePath}/${entity.domain}/${devicePart}${entityName}/${action}`;
+  }
+  // Old format: /{domain}/{object_id}/{action}
+  const objectId = entity.unique_id.split('-').slice(1).join('-');
+  return `${basePath}/${entity.domain}/${objectId}/${action}`;
+}
+
+function buildIdFetchUrl(basePath: string, id: string): string {
+  // URL-encode each path segment for fetching detail_all
+  const urlPath = id.split('/').map((s: string) => encodeURIComponent(s)).join('/');
+  return `${basePath}/${urlPath}?detail=all`;
+}
+
 interface RestAction {
   restAction(entity?: entityConfig, action?: string): void;
 }
@@ -106,8 +143,8 @@ export class EntityTable extends LitElement implements RestAction {
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       } else {
-        // is it a `detail_all` event already?
-        if (data?.name) {
+        // is it a `detail_all` event already? (has name and domain)
+        if (data?.name && data?.domain) {
           this.addEntity(data);
         } else {
           if (this._unknown_state_events[data.id]) {
@@ -121,11 +158,7 @@ export class EntityTable extends LitElement implements RestAction {
             return;
           }
 
-          let parts = data.id.split('-');
-          let domain = parts[0];
-          let id = parts.slice(1).join('-');
-
-          fetch(`${this._basePath}/${domain}/${id}?detail=all`, {
+          fetch(buildIdFetchUrl(this._basePath, data.id), {
             method: 'GET',
           })
               .then((r) => {
@@ -177,13 +210,13 @@ export class EntityTable extends LitElement implements RestAction {
   addEntity(data: any) {
     let idx = this.entities.findIndex((x) => x.unique_id === data.id);
     if (idx === -1 && data.id) {
-      // Dynamically add discovered..
-      let parts = data.id.split("-");
+      // Dynamically add discovered entity
+      // domain comes from JSON (new format) or parsed from id (old format)
+      const domain = data.domain || parseDomainFromId(data.id);
       let entity = {
         ...data,
-        domain: parts[0],
+        domain: domain,
         unique_id: data.id,
-        id: parts.slice(1).join("-"),
         entity_category: data.entity_category,
         sorting_group: data.sorting_group ?? (EntityTable.ENTITY_CATEGORIES[parseInt(data.entity_category)] || EntityTable.ENTITY_UNDEFINED),
         value_numeric_history: [data.value],
@@ -193,11 +226,11 @@ export class EntityTable extends LitElement implements RestAction {
         this.has_controls = true;
       }
       this.entities.push(entity);
-      this.entities.sort((a, b) => {  
-        const sortA = a.sorting_weight ?? a.name;  
-        const sortB = b.sorting_weight ?? b.name;  
+      this.entities.sort((a, b) => {
+        const sortA = a.sorting_weight ?? a.name;
+        const sortB = b.sorting_weight ?? b.name;
         return a.sorting_group < b.sorting_group
-          ? -1  
+          ? -1
           : a.sorting_group === b.sorting_group
           ? sortA === sortB
             ? a.name.toLowerCase() < b.name.toLowerCase()
@@ -210,7 +243,7 @@ export class EntityTable extends LitElement implements RestAction {
       });
       this.requestUpdate();
     }
-    
+
   }
 
   hasAction(entity: entityConfig): boolean {
@@ -226,7 +259,7 @@ export class EntityTable extends LitElement implements RestAction {
   }
 
   restAction(entity: entityConfig, action: string) {
-    fetch(`${this._basePath}/${entity.domain}/${entity.id}/${action}`, {
+    fetch(buildEntityActionUrl(this._basePath, entity, action), {
       method: "POST",
       headers:{
         'Content-Type': 'application/x-www-form-urlencoded'


### PR DESCRIPTION
# Support new hierarchical URL format with backward compatibility

Adds support for the new URL/ID format from esphome/esphome#12627 while maintaining compatibility with old firmware.

## New Format

- ID: `sensor/Temperature` or `sensor/Garage/Temperature` (sub-device)
- URL: `/sensor/Temperature/action` or `/sensor/Garage/Temperature/action`

## Scope

This PR enables entities with the same name on different sub-devices to work without URL collisions. Sub-device entities are displayed with a `[Device Name]` prefix (e.g., `[Kitchen Controller] Test Switch`). Full sub-device grouping in the UI would be a separate enhancement.

## Changes

**V1:**
- State event listener now handles new format IDs by finding rows via `data-*` attributes with `CSS.escape()`
- Added `buildEntityUrl()` function for URL building with data attribute support and old format fallback
- Changed loop to use block-scoped variables for proper closure capture
- Display: Sub-device entities show `[Device Name]` prefix (rendered server-side)

**V2:**
- Added `device?: string` to entityConfig interface
- Added `isNewIdFormat()`, `parseDomainFromId()`, `buildEntityActionUrl()` helper functions
- Changed entity discovery to use `parseDomainFromId()` instead of splitting by hyphen
- Changed `restAction()` to use `buildEntityActionUrl()`
- Display: Sub-device entities show `[Device Name]` prefix

**V3:**
- Same as V2 plus:
- Added `buildIdFetchUrl()` for `?detail=all` requests with old format support
- Changed detail_all check to require both name and domain
- Changed fetch URL building to use `buildIdFetchUrl()`
- Display: Sub-device entities show `[Device Name]` prefix

## Compatibility Matrix

| Firmware | ID Format | URL Built |
|----------|-----------|-----------|
| Old | `sensor-temperature` | `/sensor/temperature/action` |
| New | `sensor/Temperature` | `/sensor/Temperature/action` |
| New + device | `sensor/Garage/Temperature` | `/sensor/Garage/Temperature/action` |

## Testing

All frontends verified working with both old and new backends:

| Frontend | New Backend | Old Backend |
|----------|-------------|-------------|
| V1 | ✅ | ✅ |
| V2 | ✅ | ✅ |
| V3 | ✅ | ✅ |

Included `test_url_helpers.js` with 56 tests (attached as zip).

## Deprecation

Old URLs trigger backend warning:
```
Deprecated URL format: /button/query_status - use entity name '/button/Query status' instead. Object ID URLs will be removed in 2026.7.0.
```

**Related:** esphome/esphome#12627
