### PR TITLE
Removed weird coloring from Select/Option

### DIFF
--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -201,14 +201,8 @@ export class EntityTable extends LitElement implements RestAction {
           background-color: rgba(127, 127, 127, 0.3);
         }
         select {
-          background-color: inherit;
-          color: inherit;
           width: 100%;
           border-radius: 4px;
-        }
-        option {
-          color: currentColor;
-          background-color: var(--primary-color, currentColor);
         }
         input[type="range"], input[type="text"] {
           width: calc(100% - 8rem);

--- a/packages/v3/src/css/esp-entity-table.ts
+++ b/packages/v3/src/css/esp-entity-table.ts
@@ -5,14 +5,8 @@ export default css`
     position: relative;
   }
   select {
-    background-color: inherit;
-    color: inherit;
     width: 100%;
     border-radius: 4px;
-  }
-  option {
-    color: currentColor;
-    background-color: var(--primary-color, currentColor);
   }
   input[type="range"],
   input[type="text"] {


### PR DESCRIPTION
Apparently, modern browsers do not support proper styling of select/option components. unfortunately.

Current implementation gives weird and non-intuitive results. Especially when only two options exist.

This change removes coloring attempts and leaves browser-default behaviour which is properly understood by user.

- fixes https://github.com/esphome/esphome-webserver/issues/119

<img width="1297" height="1089" alt="image" src="https://github.com/user-attachments/assets/6b000d78-0875-4515-90f3-a023fe7aca69" />
