### PR TITLE
[captive-portal] Show link to web_server when available

### DIFF
--- a/packages/captive-portal/src/main.ts
+++ b/packages/captive-portal/src/main.ts
@@ -32,5 +32,10 @@ fetch("/config.json").then(function (response) {
     })
     document.querySelector("#net").innerHTML = html(result)
     document.querySelector("link[rel~='icon']").href = `data:image/svg+xml,${wifi(-65)}`;
+    if (config.web_server) {
+      let webServerLink = document.createElement("div");
+      webServerLink.innerHTML = `<br><hr><br><h3>Device Control</h3><a href="/?web_server">Open Web Server</a>`;
+      document.querySelector("#net").after(webServerLink);
+    }
   })
 })

--- a/packages/captive-portal/src/main.ts
+++ b/packages/captive-portal/src/main.ts
@@ -34,7 +34,7 @@ fetch("/config.json").then(function (response) {
     document.querySelector("link[rel~='icon']").href = `data:image/svg+xml,${wifi(-65)}`;
     if (config.web_server) {
       let webServerLink = document.createElement("div");
-      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server=1">Open Web Server</a><br><br><hr><br>`;
+      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server=1" target="_blank">Open Web Server</a><br><br><hr><br>`;
       // Insert before OTA Update section (third h1)
       document.body.getElementsByTagName("h1")[2].before(webServerLink);
     }

--- a/packages/captive-portal/src/main.ts
+++ b/packages/captive-portal/src/main.ts
@@ -34,7 +34,7 @@ fetch("/config.json").then(function (response) {
     document.querySelector("link[rel~='icon']").href = `data:image/svg+xml,${wifi(-65)}`;
     if (config.web_server) {
       let webServerLink = document.createElement("div");
-      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server">Open Web Server</a><br><br><hr><br>`;
+      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server=1">Open Web Server</a><br><br><hr><br>`;
       // Insert before OTA Update section (third h1)
       document.body.getElementsByTagName("h1")[2].before(webServerLink);
     }

--- a/packages/captive-portal/src/main.ts
+++ b/packages/captive-portal/src/main.ts
@@ -34,7 +34,7 @@ fetch("/config.json").then(function (response) {
     document.querySelector("link[rel~='icon']").href = `data:image/svg+xml,${wifi(-65)}`;
     if (config.web_server) {
       let webServerLink = document.createElement("div");
-      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server=1" target="_blank">Open Web Server</a><br><br><hr><br>`;
+      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server=1" target="_blank" onclick="window.open('/?web_server=1','_blank');return false;">Open Web Server</a><p style="font-size:12px;color:#666;">If this doesn't open, manually browse to ${window.location.origin}/?web_server=1</p><hr><br>`;
       // Insert before OTA Update section (third h1)
       document.body.getElementsByTagName("h1")[2].before(webServerLink);
     }

--- a/packages/captive-portal/src/main.ts
+++ b/packages/captive-portal/src/main.ts
@@ -34,8 +34,9 @@ fetch("/config.json").then(function (response) {
     document.querySelector("link[rel~='icon']").href = `data:image/svg+xml,${wifi(-65)}`;
     if (config.web_server) {
       let webServerLink = document.createElement("div");
-      webServerLink.innerHTML = `<br><hr><br><h3>Device Control</h3><a href="/?web_server">Open Web Server</a>`;
-      document.querySelector("#net").after(webServerLink);
+      webServerLink.innerHTML = `<h3>Device Control</h3><a href="/?web_server">Open Web Server</a><br><br><hr><br>`;
+      // Insert before OTA Update section (third h1)
+      document.body.getElementsByTagName("h1")[2].before(webServerLink);
     }
   })
 })


### PR DESCRIPTION
## Captive portal: Show link to web_server when available

When the device has both `captive_portal` and `web_server` enabled, show a "Device Control" link in the captive portal UI that opens the web server at `/?web_server`.

Reads the `web_server: true` field from `/config.json` (added in esphome/esphome#13089).

**Related PRs:**
- esphome/esphome#13089
- esphome/esphome-docs#5890
