### PR TITLE
Fix uptime display overflow using 64-bit JSON data

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,60 @@ web_server:
   version: 2
 ```
 
+## SSE Event Protocol
+
+The web server backend sends [Server-Sent Events](https://developer.mozilla.org/en-US/docs/Web/API/Server-Sent_Events) on the `/events` endpoint. The frontend listens for the following event types:
+
+### `ping`
+
+Sent on initial client connection (with full config) and every 10 seconds (interval keepalive).
+
+**Initial connection (full config):**
+```
+event: ping
+id: <millis()>
+data: {"title":"My Device","comment":"Living Room","ota":true,"log":true,"lang":"en","uptime":12345}
+```
+
+**Interval ping:**
+```
+event: ping
+id: <millis()>
+data: {"uptime":12345}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string | Device friendly name (or name if no friendly name set) |
+| `comment` | string | Device comment |
+| `ota` | boolean | Whether OTA updates are enabled |
+| `log` | boolean | Whether log output is exposed |
+| `lang` | string | Language code (currently always `"en"`) |
+| `uptime` | uint32 | Device uptime in **seconds** (good for ~136 years) |
+
+The SSE `id` field contains `millis()` (32-bit milliseconds) for SSE protocol reconnection compliance. This is **not** used for uptime display.
+
+**Old firmware (pre-2026.3):** Interval pings send empty `data`. Uptime is derived from `e.lastEventId` (millis, 32-bit, overflows after ~49.7 days). The `uptime` JSON field is absent from the config ping.
+
+### `log`
+
+Sent for each log message.
+
+```
+event: log
+id: <millis()>
+data: <log message with ANSI color codes>
+```
+
+### `state`
+
+Sent when an entity's state changes and on initial connection for all entities.
+
+```
+event: state
+data: {"id":"sensor-temperature","state":"23.5","value":"23.50"}
+```
+
 development
 ===========
 

--- a/packages/v2/src/esp-app.ts
+++ b/packages/v2/src/esp-app.ts
@@ -67,7 +67,13 @@ export default class EspApp extends LitElement {
       const messageEvent = e as MessageEvent;
       const d: String = messageEvent.data;
       if (d.length) {
-        this.setConfig(JSON.parse(messageEvent.data));
+        const data = JSON.parse(messageEvent.data);
+        // Only apply config when full config is present (has title).
+        // New firmware sends interval pings with only {"uptime":...}
+        // which would wipe the existing config if passed to setConfig.
+        if (data.title !== undefined) {
+          this.setConfig(data);
+        }
       }
       this.ping = messageEvent.lastEventId;
     });

--- a/packages/v3/src/esp-app.ts
+++ b/packages/v3/src/esp-app.ts
@@ -62,6 +62,7 @@ export default class EspApp extends LitElement {
   @state() ping: number = 0;
   @state() connected: boolean = true;
   @state() lastUpdate: number = 0;
+  private _hasJsonUptime: boolean = false;
   @query("#beat")
   beat!: HTMLSpanElement;
 
@@ -105,10 +106,11 @@ export default class EspApp extends LitElement {
           this.requestUpdate();
         }
         if (data.uptime !== undefined) {
-          // New firmware sends uptime in JSON data (64-bit safe)
+          // New firmware sends uptime in seconds in JSON data (overflow-safe)
           // Full config (on connect): {"title":"...","uptime":123456}
           // Interval ping: {"uptime":123456}
-          this._setUptime(data.uptime);
+          this._hasJsonUptime = true;
+          this._setUptime(data.uptime * 1000);
         } else {
           // Old firmware sends uptime in lastEventId (32-bit, may overflow after ~49 days)
           this._updateUptime(e);
@@ -121,7 +123,11 @@ export default class EspApp extends LitElement {
     });
     window.source.addEventListener("log", (e: MessageEvent) => {
       // Old firmware sends uptime in lastEventId for log events
-      this._updateUptime(e);
+      // Skip when new firmware provides uptime via JSON ping to avoid
+      // millis() overwriting the overflow-safe seconds-based value
+      if (!this._hasJsonUptime) {
+        this._updateUptime(e);
+      }
       this.lastUpdate = Date.now();
     });
     window.source.addEventListener("state", (e: MessageEvent) => {

--- a/packages/v3/src/esp-app.ts
+++ b/packages/v3/src/esp-app.ts
@@ -98,13 +98,29 @@ export default class EspApp extends LitElement {
     this.scheme = this.schemeDefault();
     window.source.addEventListener("ping", (e: MessageEvent) => {
       if (e.data?.length) {
-        this.setConfig(JSON.parse(e.data));
-        this.requestUpdate();
+        const data = JSON.parse(e.data);
+        if (data.title !== undefined) {
+          // Full config: {"title":"...","comment":"...","ota":true,"log":true,"lang":"en","uptime":123456}
+          this.setConfig(data);
+          this.requestUpdate();
+        }
+        if (data.uptime !== undefined) {
+          // New firmware sends uptime in JSON data (64-bit safe)
+          // Full config (on connect): {"title":"...","uptime":123456}
+          // Interval ping: {"uptime":123456}
+          this._setUptime(data.uptime);
+        } else {
+          // Old firmware sends uptime in lastEventId (32-bit, may overflow after ~49 days)
+          this._updateUptime(e);
+        }
+      } else {
+        // Old firmware interval ping: empty data, uptime in lastEventId
+        this._updateUptime(e);
       }
-      this._updateUptime(e);
       this.lastUpdate = Date.now();
     });
     window.source.addEventListener("log", (e: MessageEvent) => {
+      // Old firmware sends uptime in lastEventId for log events
       this._updateUptime(e);
       this.lastUpdate = Date.now();
     });
@@ -146,7 +162,7 @@ export default class EspApp extends LitElement {
   }
 
   uptime() {
-    return `${getRelativeTime(-this.ping | 0)}`;
+    return `${getRelativeTime(-this.ping || 0)}`;
   }
 
   renderOta() {
@@ -227,11 +243,15 @@ export default class EspApp extends LitElement {
     `;
   }
 
+  private _setUptime(uptime: number) {
+    this.ping = uptime;
+    this.connected = true;
+    this.requestUpdate();
+  }
+
   private _updateUptime(e: MessageEvent) {
     if (e.lastEventId) {
-      this.ping = parseInt(e.lastEventId);
-      this.connected = true;
-      this.requestUpdate();
+      this._setUptime(parseInt(e.lastEventId));
     }
   }
 


### PR DESCRIPTION
# Fix uptime display overflow after ~24.8 days

Read uptime from JSON data instead of SSE event ID to support overflow-safe values.

## Changes

### v3

- Read `data.uptime` from ping JSON (new firmware sends uptime in **seconds**)
- Convert seconds to milliseconds (`* 1000`) for `getRelativeTime()` which expects millis
- Track new firmware with `_hasJsonUptime` flag to prevent log events from overwriting the overflow-safe uptime with raw `millis()` from `lastEventId`
- Fall back to `e.lastEventId` millis for old firmware (backwards compatible)
- Guard `setConfig()` with `data.title !== undefined` so interval pings (`{"uptime":...}`) don't wipe the existing config
- Change `| 0` to `|| 0` in `uptime()` (proper null handling instead of 32-bit signed truncation)

### v2

- Guard `setConfig()` with `data.title !== undefined` so interval pings (`{"uptime":...}`) don't wipe the existing config (title, ota, comment)

### v1 / captive-portal

- No changes needed (v1 has no ping listener, captive-portal has no SSE)

## Message formats

New firmware:
- Full config: `{"title":"...","ota":true,"log":true,"lang":"en","uptime":12345}` (uptime in seconds)
- Interval ping: `{"uptime":12345}` (uptime in seconds)

Old firmware:
- Full config: `{"title":"...","ota":true,"log":true,"lang":"en"}` (no uptime field)
- Interval ping: empty data, uptime in `e.lastEventId` (32-bit millis, overflows after ~49.7 days)

## Backwards compatibility

| Frontend | Firmware | Result |
|----------|----------|--------|
| New | New | Uptime from JSON seconds, converted to millis. Log events skipped once flag set. |
| New | Old | Falls back to `lastEventId` millis throughout. Identical to previous behavior. |
| Old | New | N/A — frontend is bundled with firmware. |

Note: On initial SSE connection, there is a brief window (one loop iteration) where log events may set millis-based uptime before the deferred config ping arrives and sets the `_hasJsonUptime` flag. This is benign and self-corrects immediately.

Fixes https://github.com/esphome/esphome/issues/11928