### PR TITLE
Add climate preset, fan mode, and humidity support

### DIFF
--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -54,6 +54,26 @@ interface entityConfig {
   supports_receiver?: boolean;
 }
 
+// Clear mutually exclusive fields for domain-specific SSE state merging.
+// Climate has pairs (fan_mode/custom_fan_mode, preset/custom_preset) where
+// the backend only sends the active one; stale values from the other must be cleared.
+function mergeEntityState(entity: entityConfig, data: Record<string, any>): void {
+  if (entity.domain === "climate") {
+    if ("fan_mode" in data) delete entity.custom_fan_mode;
+    if ("custom_fan_mode" in data) delete entity.fan_mode;
+    if ("preset" in data) delete entity.custom_preset;
+    if ("custom_preset" in data) delete entity.preset;
+    if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
+      delete entity.fan_mode;
+      delete entity.custom_fan_mode;
+    }
+    if (!("preset" in data) && !("custom_preset" in data)) {
+      delete entity.preset;
+      delete entity.custom_preset;
+    }
+  }
+}
+
 export function getBasePath() {
   let str = window.location.pathname;
   return str.endsWith("/") ? str.slice(0, -1) : str;
@@ -131,22 +151,7 @@ export class EntityTable extends LitElement implements RestAction {
         delete data.name_id;
         delete data.domain;
         delete data.unique_id;
-        // Climate: clear mutually exclusive fields when their counterpart arrives
-        if (this.entities[idx].domain === "climate") {
-          if ("fan_mode" in data) delete this.entities[idx].custom_fan_mode;
-          if ("custom_fan_mode" in data) delete this.entities[idx].fan_mode;
-          if ("preset" in data) delete this.entities[idx].custom_preset;
-          if ("custom_preset" in data) delete this.entities[idx].preset;
-          // If neither in a pair is sent, both should be cleared
-          if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
-            delete this.entities[idx].fan_mode;
-            delete this.entities[idx].custom_fan_mode;
-          }
-          if (!("preset" in data) && !("custom_preset" in data)) {
-            delete this.entities[idx].preset;
-            delete this.entities[idx].custom_preset;
-          }
-        }
+        mergeEntityState(this.entities[idx], data);
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       }
@@ -632,7 +637,7 @@ class ActionRenderer {
           )}`
       : html``;
     let humidity = this.entity.current_humidity !== undefined
-      ? html`, ${this.entity.current_humidity} %`
+      ? html`&nbsp;|&nbsp;${this.entity.current_humidity} %`
       : html``;
     return html`
       <label

--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -29,8 +29,17 @@ interface entityConfig {
   max_length?: number;
   pattern?: string;
   current_temperature?: number;
+  current_humidity?: number;
   modes?: number[];
   mode?: number;
+  presets?: string[];
+  preset?: string;
+  custom_presets?: string[];
+  custom_preset?: string;
+  fan_modes?: string[];
+  fan_mode?: string;
+  custom_fan_modes?: string[];
+  custom_fan_mode?: string;
   speed_count?: number;
   speed_level?: number;
   speed: string;
@@ -122,6 +131,22 @@ export class EntityTable extends LitElement implements RestAction {
         delete data.name_id;
         delete data.domain;
         delete data.unique_id;
+        // Climate: clear mutually exclusive fields when their counterpart arrives
+        if (this.entities[idx].domain === "climate") {
+          if ("fan_mode" in data) delete this.entities[idx].custom_fan_mode;
+          if ("custom_fan_mode" in data) delete this.entities[idx].fan_mode;
+          if ("preset" in data) delete this.entities[idx].custom_preset;
+          if ("custom_preset" in data) delete this.entities[idx].preset;
+          // If neither in a pair is sent, both should be cleared
+          if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
+            delete this.entities[idx].fan_mode;
+            delete this.entities[idx].custom_fan_mode;
+          }
+          if (!("preset" in data) && !("custom_preset" in data)) {
+            delete this.entities[idx].preset;
+            delete this.entities[idx].custom_preset;
+          }
+        }
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       }
@@ -577,12 +602,44 @@ class ActionRenderer {
           this.entity.mode || ""
         )}`;
     }
+    let allPresets = [
+      "",
+      ...(this.entity.presets || []),
+      ...(this.entity.custom_presets || []),
+    ];
+    let presets = allPresets.length > 1
+      ? html`Preset:<br />
+          ${this._select(
+            this.entity,
+            "set",
+            "preset",
+            allPresets,
+            this.entity.preset || this.entity.custom_preset || ""
+          )}`
+      : html``;
+    let allFanModes = [
+      ...(this.entity.fan_modes || []),
+      ...(this.entity.custom_fan_modes || []),
+    ];
+    let fan_modes = allFanModes.length > 0
+      ? html`Fan:<br />
+          ${this._select(
+            this.entity,
+            "set",
+            "fan_mode",
+            allFanModes,
+            this.entity.fan_mode || this.entity.custom_fan_mode || ""
+          )}`
+      : html``;
+    let humidity = this.entity.current_humidity !== undefined
+      ? html`, ${this.entity.current_humidity} %`
+      : html``;
     return html`
       <label
-        >Current:&nbsp;${this.entity.current_temperature},
+        >Current:&nbsp;${this.entity.current_temperature}${humidity},
         Target:&nbsp;${target_temp_label}</label
       >
-      ${target_temp_slider} ${modes}
+      ${target_temp_slider} ${modes} ${presets} ${fan_modes}
     `;
   }
   render_valve() {

--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -54,7 +54,6 @@ interface entityConfig {
   supports_receiver?: boolean;
 }
 
-// Per-domain SSE state merge functions (like render_climate, render_light, etc.)
 // Clear mutually exclusive fields before Object.assign to prevent stale values.
 function merge_climate(entity: entityConfig, data: Record<string, any>): void {
   if ("fan_mode" in data) delete entity.custom_fan_mode;

--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -54,25 +54,26 @@ interface entityConfig {
   supports_receiver?: boolean;
 }
 
-// Clear mutually exclusive fields for domain-specific SSE state merging.
-// Climate has pairs (fan_mode/custom_fan_mode, preset/custom_preset) where
-// the backend only sends the active one; stale values from the other must be cleared.
-function mergeEntityState(entity: entityConfig, data: Record<string, any>): void {
-  if (entity.domain === "climate") {
-    if ("fan_mode" in data) delete entity.custom_fan_mode;
-    if ("custom_fan_mode" in data) delete entity.fan_mode;
-    if ("preset" in data) delete entity.custom_preset;
-    if ("custom_preset" in data) delete entity.preset;
-    if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
-      delete entity.fan_mode;
-      delete entity.custom_fan_mode;
-    }
-    if (!("preset" in data) && !("custom_preset" in data)) {
-      delete entity.preset;
-      delete entity.custom_preset;
-    }
+// Per-domain SSE state merge functions (like render_climate, render_light, etc.)
+// Clear mutually exclusive fields before Object.assign to prevent stale values.
+function merge_climate(entity: entityConfig, data: Record<string, any>): void {
+  if ("fan_mode" in data) delete entity.custom_fan_mode;
+  if ("custom_fan_mode" in data) delete entity.fan_mode;
+  if ("preset" in data) delete entity.custom_preset;
+  if ("custom_preset" in data) delete entity.preset;
+  if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
+    delete entity.fan_mode;
+    delete entity.custom_fan_mode;
+  }
+  if (!("preset" in data) && !("custom_preset" in data)) {
+    delete entity.preset;
+    delete entity.custom_preset;
   }
 }
+
+const merge_state: Record<string, (entity: entityConfig, data: Record<string, any>) => void> = {
+  climate: merge_climate,
+};
 
 export function getBasePath() {
   let str = window.location.pathname;
@@ -151,7 +152,7 @@ export class EntityTable extends LitElement implements RestAction {
         delete data.name_id;
         delete data.domain;
         delete data.unique_id;
-        mergeEntityState(this.entities[idx], data);
+        merge_state[this.entities[idx].domain]?.(this.entities[idx], data);
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       }

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -75,7 +75,6 @@ interface groupConfig {
 export const stateOn = "ON";
 export const stateOff = "OFF";
 
-// Per-domain SSE state merge functions (like render_climate, render_light, etc.)
 // Clear mutually exclusive fields before Object.assign to prevent stale values.
 function merge_climate(entity: entityConfig, data: Record<string, any>): void {
   if ("fan_mode" in data) delete entity.custom_fan_mode;

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -75,25 +75,26 @@ interface groupConfig {
 export const stateOn = "ON";
 export const stateOff = "OFF";
 
-// Clear mutually exclusive fields for domain-specific SSE state merging.
-// Climate has pairs (fan_mode/custom_fan_mode, preset/custom_preset) where
-// the backend only sends the active one; stale values from the other must be cleared.
-function mergeEntityState(entity: entityConfig, data: Record<string, any>): void {
-  if (entity.domain === "climate") {
-    if ("fan_mode" in data) delete entity.custom_fan_mode;
-    if ("custom_fan_mode" in data) delete entity.fan_mode;
-    if ("preset" in data) delete entity.custom_preset;
-    if ("custom_preset" in data) delete entity.preset;
-    if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
-      delete entity.fan_mode;
-      delete entity.custom_fan_mode;
-    }
-    if (!("preset" in data) && !("custom_preset" in data)) {
-      delete entity.preset;
-      delete entity.custom_preset;
-    }
+// Per-domain SSE state merge functions (like render_climate, render_light, etc.)
+// Clear mutually exclusive fields before Object.assign to prevent stale values.
+function merge_climate(entity: entityConfig, data: Record<string, any>): void {
+  if ("fan_mode" in data) delete entity.custom_fan_mode;
+  if ("custom_fan_mode" in data) delete entity.fan_mode;
+  if ("preset" in data) delete entity.custom_preset;
+  if ("custom_preset" in data) delete entity.preset;
+  if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
+    delete entity.fan_mode;
+    delete entity.custom_fan_mode;
+  }
+  if (!("preset" in data) && !("custom_preset" in data)) {
+    delete entity.preset;
+    delete entity.custom_preset;
   }
 }
+
+const merge_state: Record<string, (entity: entityConfig, data: Record<string, any>) => void> = {
+  climate: merge_climate,
+};
 
 export function getBasePath() {
   let str = window.location.pathname;
@@ -188,7 +189,7 @@ export class EntityTable extends LitElement implements RestAction {
         delete data.name_id;
         delete data.domain;
         delete data.unique_id;
-        mergeEntityState(this.entities[idx], data);
+        merge_state[this.entities[idx].domain]?.(this.entities[idx], data);
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       } else {

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -75,6 +75,26 @@ interface groupConfig {
 export const stateOn = "ON";
 export const stateOff = "OFF";
 
+// Clear mutually exclusive fields for domain-specific SSE state merging.
+// Climate has pairs (fan_mode/custom_fan_mode, preset/custom_preset) where
+// the backend only sends the active one; stale values from the other must be cleared.
+function mergeEntityState(entity: entityConfig, data: Record<string, any>): void {
+  if (entity.domain === "climate") {
+    if ("fan_mode" in data) delete entity.custom_fan_mode;
+    if ("custom_fan_mode" in data) delete entity.fan_mode;
+    if ("preset" in data) delete entity.custom_preset;
+    if ("custom_preset" in data) delete entity.preset;
+    if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
+      delete entity.fan_mode;
+      delete entity.custom_fan_mode;
+    }
+    if (!("preset" in data) && !("custom_preset" in data)) {
+      delete entity.preset;
+      delete entity.custom_preset;
+    }
+  }
+}
+
 export function getBasePath() {
   let str = window.location.pathname;
   return str.endsWith("/") ? str.slice(0, -1) : str;
@@ -168,22 +188,7 @@ export class EntityTable extends LitElement implements RestAction {
         delete data.name_id;
         delete data.domain;
         delete data.unique_id;
-        // Climate: clear mutually exclusive fields when their counterpart arrives
-        if (this.entities[idx].domain === "climate") {
-          if ("fan_mode" in data) delete this.entities[idx].custom_fan_mode;
-          if ("custom_fan_mode" in data) delete this.entities[idx].fan_mode;
-          if ("preset" in data) delete this.entities[idx].custom_preset;
-          if ("custom_preset" in data) delete this.entities[idx].preset;
-          // If neither in a pair is sent, both should be cleared
-          if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
-            delete this.entities[idx].fan_mode;
-            delete this.entities[idx].custom_fan_mode;
-          }
-          if (!("preset" in data) && !("custom_preset" in data)) {
-            delete this.entities[idx].preset;
-            delete this.entities[idx].custom_preset;
-          }
-        }
+        mergeEntityState(this.entities[idx], data);
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       } else {

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -39,8 +39,17 @@ interface entityConfig {
   max_length?: number;
   pattern?: string;
   current_temperature?: number;
+  current_humidity?: number;
   modes?: number[];
   mode?: number;
+  presets?: string[];
+  preset?: string;
+  custom_presets?: string[];
+  custom_preset?: string;
+  fan_modes?: string[];
+  fan_mode?: string;
+  custom_fan_modes?: string[];
+  custom_fan_mode?: string;
   speed_count?: number;
   speed_level?: number;
   speed: string;
@@ -159,6 +168,22 @@ export class EntityTable extends LitElement implements RestAction {
         delete data.name_id;
         delete data.domain;
         delete data.unique_id;
+        // Climate: clear mutually exclusive fields when their counterpart arrives
+        if (this.entities[idx].domain === "climate") {
+          if ("fan_mode" in data) delete this.entities[idx].custom_fan_mode;
+          if ("custom_fan_mode" in data) delete this.entities[idx].fan_mode;
+          if ("preset" in data) delete this.entities[idx].custom_preset;
+          if ("custom_preset" in data) delete this.entities[idx].preset;
+          // If neither in a pair is sent, both should be cleared
+          if (!("fan_mode" in data) && !("custom_fan_mode" in data)) {
+            delete this.entities[idx].fan_mode;
+            delete this.entities[idx].custom_fan_mode;
+          }
+          if (!("preset" in data) && !("custom_preset" in data)) {
+            delete this.entities[idx].preset;
+            delete this.entities[idx].custom_preset;
+          }
+        }
         Object.assign(this.entities[idx], data);
         this.requestUpdate();
       } else {
@@ -771,8 +796,11 @@ class ActionRenderer {
   render_climate() {
     if (!this.entity) return;
     let target_temp_slider, target_temp_label, target_temp;
+    let humidity = this.entity.current_humidity !== undefined
+      ? html`&nbsp;|&nbsp;${this.entity.current_humidity} %`
+      : html``;
     let current_temp = html`<div class="climate-row" style="padding-bottom: 10px";>
-                              <label>Current:&nbsp;${this.entity.current_temperature} °C</label>
+                              <label style="white-space: nowrap; width: auto;">Current:&nbsp;${this.entity.current_temperature} °C${humidity}</label>
                             </div>`;
     
     if (
@@ -833,9 +861,46 @@ class ActionRenderer {
           )}
         </div>`;
     }
+    // Combine standard and custom presets into a single dropdown
+    let allPresets = [
+      "",
+      ...(this.entity.presets || []),
+      ...(this.entity.custom_presets || []),
+    ];
+    let presets = allPresets.length > 1
+      ? html`
+          <div class="climate-row">
+            <label>Preset:&nbsp;</label>
+            ${this._select(
+              this.entity,
+              "set",
+              "preset",
+              allPresets,
+              this.entity.preset || this.entity.custom_preset || ""
+            )}
+          </div>`
+      : html``;
+    // Combine standard and custom fan modes into a single dropdown
+    let allFanModes = [
+      ...(this.entity.fan_modes || []),
+      ...(this.entity.custom_fan_modes || []),
+    ];
+    let fan_modes = allFanModes.length > 0
+      ? html`
+          <div class="climate-row">
+            <label>Fan:&nbsp;</label>
+            ${this._select(
+              this.entity,
+              "set",
+              "fan_mode",
+              allFanModes,
+              this.entity.fan_mode || this.entity.custom_fan_mode || ""
+            )}
+          </div>`
+      : html``;
     return html`
       <div class="climate-wrap">
-        ${current_temp} ${target_temp} ${modes}
+        ${current_temp} ${target_temp} ${modes} ${presets} ${fan_modes}
       </div>
     `;
   }


### PR DESCRIPTION
  ## Summary
  - Add preset/custom_preset dropdown (combined standard + custom options)
  - Add fan_mode/custom_fan_mode dropdown (combined standard + custom options)
  - Add current_humidity display next to current temperature
  - Clear mutually exclusive climate fields during SSE merge to prevent stale values
  - Reorder climate dropdowns: mode, preset, fan to match Home Assistant

  ## Context

  Companion to esphome/esphome#14061. The backend omits optional climate fields (fan_mode, preset, etc.) when unset, matching how other components work. The frontend now handles this by clearing mutually exclusive field pairs (fan_mode/custom_fan_mode, preset/custom_preset) before `Object.assign()` merges SSE state updates, preventing stale values from persisting in the UI.