### PR TITLE
Use constexpr for PROGMEM arrays in generated headers

### DIFF
--- a/scripts/make_header.sh
+++ b/scripts/make_header.sh
@@ -28,7 +28,7 @@ fi
 embed_compressed_file() {
   local input_file="$1"
   local array_name="$2"
-  echo "const uint8_t ${array_name}[] PROGMEM = {" >>"$OUTPUT_FILE"
+  echo "constexpr uint8_t ${array_name}[] PROGMEM = {" >>"$OUTPUT_FILE"
   xxd -cols 19 -i "$input_file" | sed -e '2,$!d' -e 's/^/    /' -e '$d' | sed -e '$d' | sed -e '$s/$/};/' >>"$OUTPUT_FILE"
 }
 


### PR DESCRIPTION
## Summary
- Change `const uint8_t` to `constexpr uint8_t` for PROGMEM arrays in `scripts/make_header.sh`
- `constexpr` ensures compile-time evaluation and is the correct qualifier for literal data embedded in flash

## Related
- esphome/esphome#14129 — updates the already-generated headers in the esphome repo