### PR TITLE
Publish esphome-webserver on the Docker Registries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
-/_static/
 **/node_modules/
 /Dockerfile
 /docker-compose.yml

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+/_static/
+**/node_modules/
+/Dockerfile
+/docker-compose.yml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -80,6 +80,12 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
+      - name: Set up Node.JS
+        uses: actions/setup-node@v4.0.2
+      - name: Install dependencies
+        run: npm install
+      - name: Build all packages
+        run: npm run build
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -94,7 +100,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./Dockerfile
+          file: ./Dockerfile.nginx
           push: true
           tags: |
             ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:${{ needs.release.outputs.tag }}
@@ -102,11 +108,10 @@ jobs:
           platforms: |
             linux/amd64
             linux/arm64/v8
+            linux/arm/v7
+            linux/ppc64le
+            linux/riscv64
             linux/s390x
-      - name: Verify Multi-Arch Build
-        run: |
-          docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:${{ needs.release.outputs.tag }}
-          || docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:latest
 
   esphome-pr:
     name: Make PR into ESPHome repo

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,44 @@ jobs:
           files: headers/**/*.h
           generate_release_notes: true
 
+  docker-publish:
+    name: Publish to Docker Hub
+    runs-on: ubuntu-latest
+    needs: release
+    environment:
+      name: production
+      url: https://hub.docker.com/
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4.1.1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:${{ needs.release.outputs.tag }}
+            ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:latest
+          platforms: |
+            linux/amd64
+            linux/arm64/v8
+            linux/s390x
+      - name: Verify Multi-Arch Build
+        run: |
+          docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:${{ needs.release.outputs.tag }}
+          || docker manifest inspect ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:latest
+
   esphome-pr:
     name: Make PR into ESPHome repo
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,7 +37,7 @@ jobs:
           name: ${{ matrix.name }}
           path: _static/**/*.h
 
-      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3  # v4.3.1
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: static-files
           path: _static/
@@ -85,27 +85,27 @@ jobs:
       url: https://ghcr.io/esphome/webserver
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262  # v4.4.0
 
       - name: Download static artifacts
-        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427  # v4.1.4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         with:
           pattern: static-files*
           path: _static/
           merge-multiple: true
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3.12.0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef  # v3.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4  # v6.15.0
         with:
           context: .
           file: ./Dockerfile.nginx

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,12 @@ jobs:
           name: ${{ matrix.name }}
           path: _static/**/*.h
 
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3  # v4.3.1
+        with:
+          name: static-files
+          path: _static/
+          if-no-files-found: error
+
   release:
     name: Tag and Release
     runs-on: ubuntu-latest
@@ -80,12 +86,13 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
-      - name: Set up Node.JS
-        uses: actions/setup-node@v4.0.2
-      - name: Install dependencies
-        run: npm install
-      - name: Build all packages
-        run: npm run build
+
+      - name: Download static artifacts
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427  # v4.1.4
+        with:
+          pattern: static-files*
+          path: _static/
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -71,12 +71,12 @@ jobs:
           generate_release_notes: true
 
   docker-publish:
-    name: Publish to Docker Hub
+    name: Publish to GHCR
     runs-on: ubuntu-latest
     needs: release
     environment:
       name: production
-      url: https://hub.docker.com/
+      url: https://ghcr.io/esphome/webserver
     steps:
       - name: Checkout code
         uses: actions/checkout@v4.1.1
@@ -90,11 +90,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to Docker Hub
+      - name: Log in to GHCR
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
@@ -103,8 +104,8 @@ jobs:
           file: ./Dockerfile.nginx
           push: true
           tags: |
-            ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:${{ needs.release.outputs.tag }}
-            ${{ secrets.DOCKER_HUB_USERNAME }}/esphome-webserver:latest
+            ghcr.io/esphome/webserver:${{ needs.release.outputs.tag }}
+            ghcr.io/esphome/webserver:latest
           platforms: |
             linux/amd64
             linux/arm64/v8

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:25.2.1-alpine AS packages
+WORKDIR /app/
+RUN --mount=type=bind,target=/docker-context \
+    cd /docker-context/; \
+    find . -name "package.json" -mindepth 0 -maxdepth 4 -exec cp --parents "{}" /app/ \;
+
+FROM node:25.2.1-alpine AS builder
+RUN apk add --no-cache bash
+
+WORKDIR /app
+COPY --from=packages /app/ .
+RUN npm install
+COPY . .
+RUN npm run build
+
+FROM nginx:1.29.4-alpine
+COPY --from=builder /app/_static /usr/share/nginx/html
+EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM node:25.2.1-alpine AS packages
+FROM node:25-alpine AS packages
 WORKDIR /app/
 RUN --mount=type=bind,target=/docker-context \
     cd /docker-context/; \
     find . -name "package.json" -mindepth 0 -maxdepth 4 -exec cp --parents "{}" /app/ \;
 
-FROM node:25.2.1-alpine AS builder
+FROM node:25-alpine AS builder
 RUN apk add --no-cache bash
 
 WORKDIR /app
@@ -13,6 +13,6 @@ RUN npm install
 COPY . .
 RUN npm run build
 
-FROM nginx:1.29.4-alpine
+FROM nginx:1-alpine
 COPY --from=builder /app/_static /usr/share/nginx/html
 EXPOSE 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,5 +14,5 @@ COPY . .
 RUN npm run build
 
 FROM nginx:1-alpine
-COPY --from=builder /app/_static /usr/share/nginx/html
+COPY --from=builder --chown=nginx:nginx /app/_static /usr/share/nginx/html
 EXPOSE 80

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,0 +1,3 @@
+FROM nginx:1.29.4-alpine
+COPY ./_static /usr/share/nginx/html
+EXPOSE 80

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,3 +1,3 @@
-FROM nginx:1.29.4-alpine
+FROM nginx:1-alpine
 COPY ./_static /usr/share/nginx/html
 EXPOSE 80

--- a/Dockerfile.nginx
+++ b/Dockerfile.nginx
@@ -1,3 +1,3 @@
 FROM nginx:1-alpine
-COPY ./_static /usr/share/nginx/html
+COPY  --chown=nginx:nginx ./_static /usr/share/nginx/html
 EXPOSE 80

--- a/README.md
+++ b/README.md
@@ -163,3 +163,16 @@ npm run serve
 ```
 Starts a production test server on http://localhost:5001
 Events and the json api are proxied.
+
+docker
+======
+The static files can be self-hosted using this docker compose config:
+```yaml
+services:
+  esphome-webserver:
+    image: ghcr.io/esphome/webserver
+    container_name: esphome-webserver
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  esphome-webserver:
+    build: .
+    container_name: esphome-webserver
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    read_only: true
+    tmpfs:
+      - /var/cache/nginx:size=1M,uid=101,mode=1700
+      - /var/run:size=1M


### PR DESCRIPTION
This PR is aimed at airgapped Esphome deployments without Home Assistant OS. Some users would want to point their Esphome devices at a webserver container in their network instead of [oi.esphome.io](https://oi.esphome.io). Since the static files are not included in *Home Assistant Container* by default, I'd propose publishing a separate docker image.

## Changes
- Add `Dockerfile` to build an image from source
- Add `Dockerfile.nginx` to add existing CI build artifacts to an nginx base image
- Add `docker-compose.yml` for reference
- Add a build-push-action to the CI pipeline

## Deployment
The docker images could be deployed to `esphome/esphome-webserver` on [Dockerhub](https://hub.docker.com/r/esphome/esphome-webserver) and [GHCR](https://github.com/esphome/esphome-webserver/pkgs/container/esphome-webserver).