### PR TITLE
[light] Add support for `color_temp`

### DIFF
--- a/packages/v2/src/esp-entity-table.ts
+++ b/packages/v2/src/esp-entity-table.ts
@@ -17,6 +17,7 @@ interface entityConfig {
   option?: string[];
   assumed_state?: boolean;
   brightness?: number;
+  color_temp?: number;
   target_temperature?: number;
   target_temperature_low?: number;
   target_temperature_high?: number;
@@ -412,7 +413,18 @@ class ActionRenderer {
             this.entity.brightness,
             0,
             255,
-            1
+            1,
+          )
+        : "",
+      this.entity.color_temp
+        ? this._range(
+            this.entity,
+            "turn_on",
+            "color_temp",
+            this.entity.color_temp,
+            154,
+            370,
+            1,
           )
         : "",
       this.entity.effects?.filter((v) => v != "None").length

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -25,6 +25,7 @@ interface entityConfig {
   option?: string[];
   assumed_state?: boolean;
   brightness?: number;
+  color_temp?: number;
   color_mode?: string;
   color: object;
   target_temperature?: number;
@@ -688,9 +689,20 @@ class ActionRenderer {
               "turn_on",
               "brightness",
               this.entity.brightness,
-              0,
-              255,
-              1
+              "0",
+              "255",
+              1,
+            )
+          : ""}
+        ${this.entity.color_temp
+          ? this._range(
+              this.entity,
+              "turn_on",
+              "color_temp",
+              this.entity.color_temp,
+              "154",
+              "370",
+              1,
             )
           : ""}
         ${this.entity.color_mode === "rgb" || this.entity.color_mode === "rgbw"


### PR DESCRIPTION
The range [154, 370] Mired corresponds to about [6500, 2700] K.

This also fixes a type mismatch in v3 where min/max are handled as strings, not numbers.