### PR TITLE
Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,9 +22,9 @@ jobs:
             directory: v3
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
       - name: Set up Node.JS
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8  # v4.0.2
       - name: Install dependencies
         run: npm install
       - name: Build ${{ matrix.name }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,10 +20,10 @@ jobs:
             directory: v3
     steps:
       - name: Clone the repo
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
       - name: Set up Node.JS
-        uses: actions/setup-node@v4.0.2
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8  # v4.0.2
 
       - name: Install dependencies
         run: npm install
@@ -32,7 +32,7 @@ jobs:
         run: npm run build
         working-directory: packages/${{ matrix.directory }}
 
-      - uses: actions/upload-artifact@v4.3.1
+      - uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3  # v4.3.1
         with:
           name: ${{ matrix.name }}
           path: _static/**/*.h
@@ -46,14 +46,14 @@ jobs:
     steps:
       # Checkout repo, create new git tag, and git release with artifacts
       - name: Checkout the repo
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
 
       - name: Create a new tag
         id: create_tag
         run: echo tag=$(date +'%Y%m%d-%H%M%S') >> $GITHUB_OUTPUT
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427  # v4.1.4
         with:
           path: headers
           merge-multiple: true
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create a release
         id: create_release
-        uses: softprops/action-gh-release@v2.0.4
+        uses: softprops/action-gh-release@9d7c94cfd0a1f3ed45544c887983e9fa900f0564  # v2.0.4
         with:
           tag_name: ${{ steps.create_tag.outputs.tag }}
           name: Release ${{ steps.create_tag.outputs.tag }}
@@ -78,13 +78,13 @@ jobs:
       - release
     steps:
       - name: Checkout esphome repo
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11  # v4.1.1
         with:
           repository: esphome/esphome
           ref: dev
 
       - name: Download Artifacts
-        uses: actions/download-artifact@v4.1.4
+        uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427  # v4.1.4
         with:
           path: /tmp/headers
           merge-multiple: true
@@ -96,7 +96,7 @@ jobs:
           mv /tmp/headers/v3/server_index_v3.h esphome/components/web_server/server_index_v3.h
 
       - name: PR Changes
-        uses: peter-evans/create-pull-request@v6.0.4
+        uses: peter-evans/create-pull-request@9153d834b60caba6d51c9b9510b087acf9f33f83  # v6.0.4
         with:
           commit-message: "Update webserver local assets to ${{ needs.release.outputs.tag }}"
           committer: esphomebot <68923041+esphomebot@users.noreply.github.com>


### PR DESCRIPTION
## Summary

Pin all GitHub Action and reusable workflow references to their full commit SHAs
instead of mutable tags or branch names.

Closes #200


## Why?

Referencing actions by tag (e.g., `actions/checkout@v4`) is convenient but
carries a supply-chain risk: tags are mutable and can be force-pushed to point
at arbitrary commits. If an action's tag is compromised, every workflow that
references it by tag will silently run the attacker's code.

Pinning to a full 40-character commit SHA (e.g.,
`actions/checkout@11bd719...`) makes the reference immutable. Even if a tag is
tampered with, workflows pinned to a SHA will continue to use the exact code
that was reviewed and trusted.

A version comment is included next to each SHA for readability
(e.g., `actions/checkout@11bd719... # v4.2.2`).

## References

- [GitHub Blog: Four tips to keep your GitHub Actions workflows secure](https://github.blog/open-source/four-tips-to-keep-your-github-actions-workflows-secure/#use-specific-action-version-tags)
- [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)
- [GitHub Docs: Enforcing SHA pinning for actions](https://docs.github.com/en/organizations/managing-organization-settings/disabling-or-limiting-github-actions-for-your-organization#requiring-workflows-to-use-pinned-versions-of-actions)
