### PR TITLE
Update esp-logo.ts

### DIFF
--- a/packages/v3/src/esp-logo.ts
+++ b/packages/v3/src/esp-logo.ts
@@ -1,4 +1,4 @@
-import { LitElement, svg } from "lit";
+import { LitElement, html } from "lit";
 import { customElement } from "lit/decorators.js";
 
 import logo from "/logo.svg?raw";
@@ -6,6 +6,6 @@ import logo from "/logo.svg?raw";
 @customElement("esp-logo")
 export default class EspLogo extends LitElement {
   render() {
-    return svg([logo]);
+    return html(Object.assign([logo], { raw: [logo] }));
   }
 }


### PR DESCRIPTION
The [ESPHome logo](https://raw.githubusercontent.com/esphome/esphome-webserver/refs/heads/dev/packages/v3/public/logo.svg), which is implemented via a complete stand-alone set of tags rather than the innerHTML of an `svg` tag, does not get displayed and throws a console error per [issue #207](https://github.com/esphome/esphome-webserver/issues/207), apparently due to a misapplication of the `svg` *tag function*.  Per [lit-html documentation](https://github.com/lit/lit/blob/main/packages/lit-html/src/lit-html.ts#L626):
 * The `svg` *tag function* should only be used for SVG fragments, or elements
 * that would be contained **inside** an `<svg>` HTML element. A common error is
 * placing an `<svg>` *element* in a template tagged with the `svg` tag
 * function. The `<svg>` element is an HTML element and should be used within a
 * template tagged with the {@linkcode html} tag function.

This PR demonstrates _an_ ES6 compliant way to fix the problem for the v3 webserver. Suspecting that the maintainers will likely prefer a stylistically different fix, I leave that to others, along with v1 and v2 patches.