### PR TITLE
fix(cover): render neutral buttons when assumed_state is set

### DIFF
--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -718,7 +718,11 @@ class ActionRenderer {
 
   render_cover() {
     if (!this.entity) return;
-    return html`${this._actionButton(this.entity, "↑", "open", this.entity.state === "OPEN")}
+    if (this.entity.assumed_state)
+      return html`${this._actionButton(this.entity, "↑", "open")}
+      ${this._actionButton(this.entity, "☐", "stop")}
+      ${this._actionButton(this.entity, "↓", "close")}`;
+    else return html`${this._actionButton(this.entity, "↑", "open", this.entity.state === "OPEN")}
     ${this._actionButton(this.entity, "☐", "stop")}
     ${this._actionButton(this.entity, "↓", "close", this.entity.state === "CLOSED")}`;
   }

--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -718,13 +718,15 @@ class ActionRenderer {
 
   render_cover() {
     if (!this.entity) return;
-    if (this.entity.assumed_state)
+    if (this.entity.assumed_state) {
       return html`${this._actionButton(this.entity, "↑", "open")}
       ${this._actionButton(this.entity, "☐", "stop")}
       ${this._actionButton(this.entity, "↓", "close")}`;
-    else return html`${this._actionButton(this.entity, "↑", "open", this.entity.state === "OPEN")}
-    ${this._actionButton(this.entity, "☐", "stop")}
-    ${this._actionButton(this.entity, "↓", "close", this.entity.state === "CLOSED")}`;
+    } else {
+      return html`${this._actionButton(this.entity, "↑", "open", this.entity.state === "OPEN")}
+      ${this._actionButton(this.entity, "☐", "stop")}
+      ${this._actionButton(this.entity, "↓", "close", this.entity.state === "CLOSED")}`;
+    }
   }
 
   render_button() {


### PR DESCRIPTION
WARNING: the code has been developed with claude

render_cover() passed isCurrentState to _actionButton() without checking assumed_state, disabling the open/close button matching the current state even with assumed_state: true. Add an early-return mirroring render_switch() that renders neutral buttons (no highlight, never disabled) when assumed_state is set.

Depends on esphome/esphome#16799 for the backend to emit the flag.
Fixes esphome/esphome-webserver#209