### PR TITLE
Sort by sub-device first, then by name

### DIFF
--- a/packages/v3/src/esp-entity-table.ts
+++ b/packages/v3/src/esp-entity-table.ts
@@ -19,6 +19,7 @@ interface entityConfig {
   value: string;
   name: string;
   device?: string;  // Device name for hierarchical URLs (sub-devices only)
+  display_name: string;
   entity_category?: number;
   when: string;
   icon?: string;
@@ -241,6 +242,7 @@ export class EntityTable extends LitElement implements RestAction {
         entity_category: data.entity_category,
         sorting_group: data.sorting_group ?? (EntityTable.ENTITY_CATEGORIES[parseInt(data.entity_category)] || EntityTable.ENTITY_UNDEFINED),
         value_numeric_history: [data.value],
+        display_name: data.device ? `[${data.device}] ${data.name}` : data.name,
       } as entityConfig;
       entity.has_action = this.hasAction(entity);
       if (entity.has_action) {
@@ -248,13 +250,13 @@ export class EntityTable extends LitElement implements RestAction {
       }
       this.entities.push(entity);
       this.entities.sort((a, b) => {
-        const sortA = a.sorting_weight ?? a.name;
-        const sortB = b.sorting_weight ?? b.name;
+        const sortA = a.sorting_weight ?? a.display_name;
+        const sortB = b.sorting_weight ?? b.display_name;
         return a.sorting_group < b.sorting_group
           ? -1
           : a.sorting_group === b.sorting_group
           ? sortA === sortB
-            ? a.name.toLowerCase() < b.name.toLowerCase()
+            ? a.display_name.toLowerCase() < b.display_name.toLowerCase()
               ? -1
               : 1
             : sortA < sortB
@@ -363,7 +365,7 @@ export class EntityTable extends LitElement implements RestAction {
                           ></iconify-icon>`
                         : nothing}
                     </div>
-                    <div>${component.device ? `[${component.device}] ` : ''}${component.name}</div>
+                    <div>${component.display_name}</div>
                     <div>
                       ${this.has_controls && component.has_action
                         ? this.control(component)


### PR DESCRIPTION
This adds a `display_name` property to the entity interface which is initialized with the name as it is displayed (`[device name] entity name` / `entity name`) for both sorting and displaying.

Right now, (if no sort groups / weights are set) the sorting looks like this:

- [Device A] Sensor 1
- [Device B] Sensor 1
- [Device A] Sensor 2
- [Device B] Sensor 2

Or sometimes even like this (because same names have the same weight):

- [Device A] Sensor 1
- [Device B] Sensor 1
- [Device B] Sensor 2
- [Device A] Sensor 2

This adds the device name to the sort order, so by default it is sorted as it is displayed:

- [Device A] Sensor 1
- [Device A] Sensor 2
- [Device B] Sensor 1
- [Device B] Sensor 2

Fixes #206 