### PR TITLE
Refactor captive portal network list rendering

### DIFF
--- a/packages/captive-portal/public/config.json
+++ b/packages/captive-portal/public/config.json
@@ -1,9 +1,27 @@
-{"name":"My ESPhome",
-    "aps":[
-        {}
-        ,{"ssid":"Hermione","rssi":-50,"lock":0}
-        ,{"ssid":"Neville","rssi":-65,"lock":1}
-        ,{"ssid":"Gandalf the Grey","rssi":-85,"lock":1}
-        ,{"ssid":"Hagrid","rssi":-95,"lock":0}
+{
+    "mac": "AA:BB:CC:DD:EE:FF",
+    "name": "My ESPhome",
+    "aps": [
+        {},
+        {
+            "ssid": "Hermione",
+            "rssi": -50,
+            "lock": 0
+        },
+        {
+            "ssid": "Neville",
+            "rssi": -65,
+            "lock": 1
+        },
+        {
+            "ssid": "Gandalf the Grey",
+            "rssi": -85,
+            "lock": 1
+        },
+        {
+            "ssid": "Hagrid",
+            "rssi": -95,
+            "lock": 0
+        }
     ]
 }

--- a/packages/captive-portal/src/main.ts
+++ b/packages/captive-portal/src/main.ts
@@ -1,36 +1,49 @@
 if (document.location.search === "?save") document.getElementsByTagName("aside")[0].style.display = "block";
+interface Ap {
+  ssid: string;
+  rssi: number;
+  lock: number;
+}
+interface Config {
+  mac: string;
+  name: string;
+  aps: Ap[]; // first entry is always {} and is skipped via slice(1)
+}
 function wifi(dBm: number) {
   let q = Math.max(Math.min(2 * (dBm + 100), 100), 0) / 100;
   return svg(`<path d="M12 19.25L.7 4.25c7-5 14-5 22.5 0z" fill="none" stroke="currentColor"/>
 <path d="M12 19.25L.7 4.25c7-5 14-5 22.5 0z" transform="scale(${q} ${q})" transform-origin="12 18"/>`)
 }
-function svg(el:String) {
+function svg(el: string) {
   return html([`<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">${el}</svg>`])
 }
-function lock(show: boolean) {
+function lock(show: number) {
   return show
     ? svg(`<path d='M12 17a2 2 0 0 0 2-2 2 2 0 0 0-2-2 2 2 0 0 0-2 2 2 2 0 0 0 2 2m6-9a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V10a2 2 0 0 1 2-2h1V6a5 5 0 0 1 5-5 5 5 0 0 1 5 5v2h1m-6-5a3 3 0 0 0-3 3v2h6V6a3 3 0 0 0-3-3z'/>`)
     : ""
 }
-function html(h: String[]) {
+function html(h: string[]) {
   return h.join("");
 }
 fetch("/config.json").then(function (response) {
-  response.json().then(function (config) {
+  response.json().then(function (config: Config) {
     document.title = config.name;
-    document.body.getElementsByTagName("h1")[0].innerText = "MAC Address: " + config.mac
-    document.body.getElementsByTagName("h1")[1].innerText = "WiFi Networks: " + config.name
-    let result = config.aps.slice(1).map(function (ap) {
-      return `<div class="network" 
-      onclick="document.getElementById('ssid').value = this.innerText;document.getElementById('psk').focus()">
-      <a href="#" class="network-left">
-        ${wifi(ap.rssi)}
-        <span class="network-ssid">${ap.ssid}</span>
-      </a>
-      ${lock(ap.lock)}
-      </div>`
-    })
-    document.querySelector("#net").innerHTML = html(result)
-    document.querySelector("link[rel~='icon']").href = `data:image/svg+xml,${wifi(-65)}`;
-  })
-})
+    (document.getElementById("mac") as HTMLElement).innerText = "MAC Address: " + config.mac;
+    (document.getElementById("h1") as HTMLElement).innerText = "WiFi Networks: " + config.name;
+    let net = document.getElementById("net") as HTMLElement;
+    let ssid = document.getElementById("ssid") as HTMLInputElement;
+    let psk = document.getElementById("psk") as HTMLInputElement;
+    config.aps.slice(1).forEach(function (ap) {
+      let div = document.createElement("div");
+      div.className = "network";
+      div.innerHTML = `<a href="#" class="network-left">${wifi(ap.rssi)}<span class="network-ssid"></span></a>${lock(ap.lock)}`;
+      (div.querySelector(".network-ssid") as HTMLElement).textContent = ap.ssid;
+      div.onclick = function () {
+        ssid.value = ap.ssid;
+        psk.focus();
+      };
+      net.appendChild(div);
+    });
+    (document.querySelector("link[rel~='icon']") as HTMLLinkElement).href = `data:image/svg+xml,${wifi(-65)}`;
+  });
+});


### PR DESCRIPTION
Tidies up how the captive portal renders its list of scanned networks.

The rows are now built with DOM APIs and a real click handler, replacing the previous approach of assembling one large HTML string with an inline `onclick` attribute that scraped `this.innerText` back out of the row to recover the SSID.

Headings are looked up via their existing `#mac` and `#h1` IDs rather than positional `getElementsByTagName("h1")` indexes.

Adds `Ap` and `Config` interfaces documenting the shape the firmware emits from `/config.json`, and swaps the boxed `String` types for the `string` primitive. `lock` is typed as `number`, since the firmware writes it with printf `%d` and it arrives as `0`/`1` rather than a JSON boolean.

Also adds `mac` to the sample `public/config.json` so the dev preview populates the MAC heading.

Built output grows by 19 bytes gzipped (1462 -> 1481).