### PR TITLE
Fix indentation of generated binary arrays

### DIFF
--- a/scripts/make_header.sh
+++ b/scripts/make_header.sh
@@ -29,7 +29,9 @@ embed_compressed_file() {
   local input_file="$1"
   local array_name="$2"
   echo "constexpr uint8_t ${array_name}[] PROGMEM = {" >>"$OUTPUT_FILE"
-  xxd -cols 19 -i "$input_file" | sed -e '2,$!d' -e 's/^/    /' -e '$d' | sed -e '$d' | sed -e '$s/$/};/' >>"$OUTPUT_FILE"
+  # xxd -i already indents byte rows by 2 spaces; normalize to the 4-space
+  # continuation indent that esphome's clang-format config expects.
+  xxd -cols 19 -i "$input_file" | sed -e '2,$!d' -e 's/^ */    /' -e '$d' | sed -e '$d' | sed -e '$s/$/};/' >>"$OUTPUT_FILE"
 }
 
 cat <<EOT >"$OUTPUT_FILE"


### PR DESCRIPTION
`xxd -i` already indents its byte rows by two spaces, and the sed filter in `scripts/make_header.sh` prepended four more. Generated headers therefore used a six-space indent for the `INDEX_GZ`/`INDEX_BR` byte rows, two more than the four-space continuation indent esphome's clang-format config expects.

Changing `s/^/    /` to `s/^ */    /` strips xxd's own indent before applying the four spaces, so the rows land at exactly four. The `};` terminator handling is unchanged.