### PR TITLE
Fix esp-logo rendering nothing in v2 and v3

### DIFF
--- a/packages/v2/src/esp-logo.ts
+++ b/packages/v2/src/esp-logo.ts
@@ -1,11 +1,24 @@
-import { LitElement, svg } from "lit";
+import { LitElement, css } from "lit";
 import { customElement } from "lit/decorators.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import logo from "/logo.svg?raw";
 
 @customElement("esp-logo")
 export default class EspLogo extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+  `;
+
   render() {
-    return svg([logo]);
+    // The logo is a trusted build-time asset inlined by vite's `?raw` import.
+    return unsafeHTML(logo);
   }
 }

--- a/packages/v3/src/esp-logo.ts
+++ b/packages/v3/src/esp-logo.ts
@@ -1,11 +1,24 @@
-import { LitElement, svg } from "lit";
+import { LitElement, css } from "lit";
 import { customElement } from "lit/decorators.js";
+import { unsafeHTML } from "lit/directives/unsafe-html.js";
 
 import logo from "/logo.svg?raw";
 
 @customElement("esp-logo")
 export default class EspLogo extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+    }
+    svg {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+  `;
+
   render() {
-    return svg([logo]);
+    // The logo is a trusted build-time asset inlined by vite's `?raw` import.
+    return unsafeHTML(logo);
   }
 }


### PR DESCRIPTION
`packages/v2/src/esp-logo.ts` and `packages/v3/src/esp-logo.ts` both rendered nothing. `svg([logo])` calls lit's `svg` tag function as an ordinary function with a plain array that has no `raw` property. lit's development build throws `invalid template strings array`, and the production build silently renders an empty comment node, so the header showed no logo at all on any device running v2 or v3.

This swaps it for the `unsafeHTML` directive, which is the supported way to render a trusted pre-built markup string and does internally what the broken call was open-coding by hand. The logo is a build-time asset inlined by vite's `?raw` import, so no untrusted input is involved. It is a standalone `<svg>` element rather than an SVG fragment, which per lit's own guidance belongs in an HTML template rather than an `svg` one.

The change also pins the SVG to the host box. The asset carries `viewBox="0 0 128 124.68"` and no intrinsic `width`/`height`, so the moment it started rendering it laid out 52x50.6 inside the declared 52x40 host and spilled into the subtitle row.

Verified by serving each built `_static/vN` bundle against a mock device that answers `GET /events` with an SSE config ping followed by per-entity state events. Before the change `esp-logo`'s shadow root contained only `<!---->`; after it contains one `<svg>` in the SVG namespace with both paths, the correct fills from the asset's embedded `<style>` block, and a bounding box exactly matching the 52x40 host. Confirmed in both v2 and v3.

`packages/v1` has no `esp-logo` (it is plain JS and CSS with no lit), so v2 and v3 are the complete set of affected packages.

Supersedes #208, which diagnosed the same root cause and fixed v3 only.

Closes #207
Closes #208