### PR TITLE
Replace Chart.js with an inline SVG sparkline in v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -123,12 +123,6 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
-      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.6.0.tgz",
@@ -1337,18 +1331,6 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/chart.js": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.1.tgz",
-      "integrity": "sha512-GIjfiT9dbmHRiYi6Nl2yFCq7kkwdkp1W/lp2J99rX0yo9tgJGn3lKQATztIjb5tVtevcBtIdICNWqlq5+E8/Pw==",
-      "license": "MIT",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
     },
     "node_modules/commander": {
       "version": "15.0.0",
@@ -2597,7 +2579,6 @@
       "name": "@esphome-webserver/v3",
       "version": "3.0.0",
       "dependencies": {
-        "chart.js": "^4.5.1",
         "iconify-icon": "^3.0.2",
         "lit": "^3.3.3"
       },

--- a/packages/v3/package.json
+++ b/packages/v3/package.json
@@ -11,7 +11,6 @@
     "deploy": "bash -c '../../scripts/make_header.sh ../../_static/v3 server_index_v3.h web_server 3'"
   },
   "dependencies": {
-    "chart.js": "^4.5.1",
     "iconify-icon": "^3.0.2",
     "lit": "^3.3.3"
   },

--- a/packages/v3/src/esp-entity-chart.ts
+++ b/packages/v3/src/esp-entity-chart.ts
@@ -1,91 +1,87 @@
-import { html, css, LitElement, TemplateResult, nothing } from "lit";
-import { customElement, state, property } from "lit/decorators.js";
-import {
-  Chart,
-  Colors,
-  LineController,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement,
-} from "chart.js";
+import { html, css, LitElement } from "lit";
+import { customElement, property } from "lit/decorators.js";
 
-Chart.register(
-  Colors,
-  LineController,
-  CategoryScale,
-  LinearScale,
-  PointElement,
-  LineElement
-);
+// Viewport is a fixed 0..100 box scaled to the host with preserveAspectRatio="none".
+// The line is inset vertically so the stroke is not clipped at the extremes.
+const TOP = 4;
+const BOTTOM = 96;
 
 @customElement("esp-entity-chart")
 export class ChartElement extends LitElement {
-  @property({ type: Array }) chartdata = [];
-  private chartSubComponent: Chart;
+  @property({ type: Array }) chartdata: number[] = [];
 
-  constructor() {
-    super();
-  }
+  private _observer?: MutationObserver;
 
-  updated(changedProperties: Map<string, unknown>) {
-    super.updated(changedProperties);
-    if (changedProperties.has("chartdata")) {
-      this.chartSubComponent.data.datasets[0].data = this.chartdata;
-      this.chartSubComponent.data.labels = this.chartdata;
-      this.chartSubComponent?.update();
-    }
-  }
-
-  firstUpdated() {
-    const ctx = this.renderRoot.querySelector("canvas").getContext("2d");
-    this.chartSubComponent = new Chart(ctx, {
-      type: "line",
-      data: {
-        labels: this.chartdata,
-        datasets: [
-          {
-            data: this.chartdata,
-            borderWidth: 1,
-            tension: 0.3,
-          },
-        ],
-      },
-      options: {
-        animation: { duration: 0 },
-        plugins: { legend: { display: false } },
-        scales: { x: { display: false }, y: { position: "right" } },
-        responsive: true,
-        maintainAspectRatio: false,
-      },
-    });
-    this.updateStylesIfExpanded();
-  }
-  // since the :host-context(.expanded) selector is not supported in Safari and Firefox we need to use JS to apply styles
-  // whether the parent element is expanded or not
-  updateStylesIfExpanded() {
-    const parentElement = this.parentElement;
-    const expandedClass = "expanded";
-
-    const applyStyles = () => {
-      if (parentElement && parentElement.classList.contains(expandedClass)) {
-        this.style.height = "240px";
-        this.style.opacity = "0.5";
-      } else {
-        this.style.height = "42px";
-        this.style.opacity = "0.1";
-      }
-    };
-
-    applyStyles();
-
-    // Observe class changes
-    const observer = new MutationObserver(applyStyles);
-    if (parentElement)
-      observer.observe(parentElement, {
+  connectedCallback() {
+    super.connectedCallback();
+    this._applyExpandedStyles();
+    const parent = this.parentElement;
+    if (parent) {
+      this._observer = new MutationObserver(() => this._applyExpandedStyles());
+      this._observer.observe(parent, {
         attributes: true,
         attributeFilter: ["class"],
       });
+    }
+  }
+
+  disconnectedCallback() {
+    this._observer?.disconnect();
+    this._observer = undefined;
+    super.disconnectedCallback();
+  }
+
+  // since the :host-context(.expanded) selector is not supported in Safari and Firefox we need to use JS to apply styles
+  // whether the parent element is expanded or not
+  private _applyExpandedStyles() {
+    const expanded = this.parentElement?.classList.contains("expanded");
+    this.style.height = expanded ? "240px" : "42px";
+    this.style.opacity = expanded ? "0.5" : "0.1";
+  }
+
+  // The history is seeded with an unguarded `data.value` (esp-entity-table only
+  // typechecks on append), so element 0 can be null or a string. Number.isFinite
+  // does not coerce, so those are dropped instead of becoming spurious 0 points.
+  private _values(): number[] {
+    return (this.chartdata || []).filter(Number.isFinite);
+  }
+
+  private _points(values: number[]): string {
+    if (values.length === 0) return "";
+    const min = Math.min(...values);
+    const span = Math.max(...values) - min;
+    const step = values.length > 1 ? 100 / (values.length - 1) : 0;
+    return values
+      .map((v, i) => {
+        const x = values.length > 1 ? i * step : 50;
+        const y = span > 0 ? BOTTOM - ((v - min) / span) * (BOTTOM - TOP) : 50;
+        return `${x.toFixed(2)},${y.toFixed(2)}`;
+      })
+      .join(" ");
+  }
+
+  // Axis labels are raw sensor readings, so trim them to something readable
+  // rather than printing the full float.
+  private _label(value: number | undefined) {
+    return value === undefined ? "" : Number(value.toPrecision(4));
+  }
+
+  render() {
+    const values = this._values();
+    const min = this._label(values.length ? Math.min(...values) : undefined);
+    const max = this._label(values.length ? Math.max(...values) : undefined);
+    return html`
+      <svg viewBox="0 0 100 100" preserveAspectRatio="none">
+        <polyline
+          points="${this._points(values)}"
+          vector-effect="non-scaling-stroke"
+        ></polyline>
+      </svg>
+      <div class="axis">
+        <span>${max}</span>
+        <span>${min}</span>
+      </div>
+    `;
   }
 
   static get styles() {
@@ -97,10 +93,31 @@ export class ChartElement extends LitElement {
         width: calc(100% - 42px);
         z-index: -100;
       }
+      svg {
+        display: block;
+        width: 100%;
+        height: 100%;
+      }
+      polyline {
+        fill: none;
+        stroke: var(--primary-color, #03a9f4);
+        stroke-width: 1;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+      }
+      .axis {
+        position: absolute;
+        top: 0;
+        right: 0;
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        justify-content: space-between;
+        align-items: flex-end;
+        font-size: 10px;
+        line-height: 1;
+        pointer-events: none;
+      }
     `;
-  }
-
-  render() {
-    return html`<canvas></canvas>`;
   }
 }


### PR DESCRIPTION
Chart.js was 146 KiB raw / 44 KiB brotli, about 66% of the entire v3 bundle, to draw a 50-point sparkline with hidden axes, no animation, no legend, no tooltips and no interaction. This is an ESP32 webserver where flash is scarce, so this replaces it with a hand-rolled inline SVG polyline.

| Artifact            | Before              | After               | Change              |
| ------------------- | ------------------- | ------------------- | ------------------- |
| `www.js`            | 217.0 KiB           | 74.6 KiB            | -65.6%              |
| `www.js.br`         | 64.6 KiB            | 21.7 KiB            | -66.3%              |
| `server_index_v3.h` | 861.3 KiB           | 288.7 KiB           | -66.5%              |

`server_index_v3.h` is the artifact that actually lands in flash: 862 KiB down to 289 KiB.

## How the sparkline works

A fixed `0 0 100 100` viewBox with `preserveAspectRatio="none"` lets the line stretch to any host size without recomputing points on resize, and `vector-effect="non-scaling-stroke"` keeps the stroke 1px despite the non-uniform scale. The min/max labels are HTML in a flex column rather than SVG `<text>`, precisely because that non-uniform scale would distort text. The line is inset to y 4..96 so the stroke is not clipped at the extremes, and a flat series centres at y=50 rather than dividing by zero.

Labels go through `toPrecision(4)`; without it they render as `25.498080634322925`, since Chart.js used to round these for us.

## Bugs this fixes along the way

**The expanded chart never actually grew.** Clicking a row set the host to 240px, but Chart.js sizes its canvas from `parentElement`, and in shadow DOM the canvas's parent node is the `ShadowRoot`, not an element. It never found a container to measure and stayed locked at the 42px it had at `firstUpdated`, so the expanded view was a 42px chart in a 240px slot. The SVG fills the host properly because it scales rather than measures.

**Two leaks per recycled row.** The `MutationObserver` was never disconnected and `chart.destroy()` was never called. The observer is now torn down in `disconnectedCallback`.

**A null reading became a 0 point.** `value_numeric_history` is seeded with an unguarded `data.value` (`esp-entity-table` only typechecks on append), so a sensor with no reading yet seeded `null`. The old filter coerced it, and `Number(null)` is `0`, which is finite. For a series around 21.5 that spurious 0 set the minimum, squashing the line into the top 2% of the box and mislabelling the axis. `Number.isFinite` does not coerce, so the seed is now dropped instead.

Verified against a mock device: 50 points, no NaN, correct axis labels, live updates, and expand/collapse all behave, with no console errors.